### PR TITLE
Major update as of August, 2020. VERSION INCREMENT to 9.

### DIFF
--- a/gnss/io/pony_gnss_io_rinex.c
+++ b/gnss/io/pony_gnss_io_rinex.c
@@ -1,0 +1,1588 @@
+// Aug-2020
+//
+/*	pony_gnss_io_rinex 
+	
+	pony plugins for GNSS RINEX input/output:
+
+	- pony_gnss_io_rinex_v3_read_obs_from_file 
+		Reads observation data (measurements) from RINEX v3.0x files, including header and data records.
+		Supports GPS, GLONASS, Galileo and BeiDou systems.
+		Multi-receiver/multi-antenna capable, with syncronization option.
+		Does not support header updates after END OF HEADER line.
+		Only limited number of header labels are processed. 
+
+	- pony_gnss_io_rinex_read_eph_from_file
+		Reads navigation data (ephemeris) from RINEX v2-3 files, including header and data records.
+		Supports GPS, GLONASS, Galileo and BeiDou systems.
+		Multi-receiver/multi-antenna capable.
+		Does not support header updates after END OF HEADER line.
+		Only limited number of header labels are processed.
+	
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../pony.h"
+
+// pony bus version check
+#define PONY_GNSS_IO_RINEX_BUS_VERSION_REQUIRED 7
+#if PONY_BUS_VERSION < PONY_GNSS_IO_RINEX_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+// internal defines
+#define PONY_GNSS_IO_RINEX_BUFFER_SIZE 2048
+
+// internal routines
+	// RINEX routines
+		// observation files
+char   pony_gnss_io_rinex_v3_obs_file_header_read(pony_gnss *gnss, FILE *fp, char *buf);
+char   pony_gnss_io_rinex_v3_obs_file_record_read(pony_gnss *gnss, FILE *fp, char *buf);
+int    pony_gnss_io_rinex_v3_obs_file_record_read_parse_entry(char *buf, const size_t width, const char *fmt, void *dest);
+char   pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(size_t *obs_count, char (**obs_types)[4], pony_gnss_sat *sat,  char *buf, const size_t len, const size_t sat_count, char flag);
+char   pony_gnss_io_rinex_obs_file_header_parse_glo_slot_frq(pony_gnss_glo *,  char *buf, const size_t len, char flag);
+char   pony_gnss_io_rinex_obs_file_record_parse_obs_line(pony_gnss_sat *sat,  char *buf, const size_t len, const size_t sat_count, const size_t obs_count);
+		// ephemeris files
+char   pony_gnss_io_rinex_eph_file_header_read(pony_gnss *gnss, FILE *fp, char *buf);
+char   pony_gnss_io_rinex_eph_file_header_parse_iono_corr(pony_gnss *gnss,  char *buf, const size_t len);
+char   pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(double *iono,  char *buf, const size_t len, const size_t field_count);
+char   pony_gnss_io_rinex_eph_file_header_parse_time_corr(pony_gnss *gnss,  char *buf, const size_t len);
+void   pony_gnss_io_rinex_eph_file_header_parse_time_corr_line(double *clock_corr, char *time_sys, char *valid,  char *buf, const size_t len);
+char   pony_gnss_io_rinex_file_header_parse_leap_sec(pony_gnss *gnss,  char *buf, const size_t len);
+void   pony_gnss_io_rinex_eph_file_records_read(pony_gnss_sat *sat, pony_time_epoch *epoch, FILE *fp, char *buf, double *eph, unsigned int *sn, const size_t sys, const size_t maxsat, const size_t maxeph);
+char   pony_gnss_io_rinex_eph_file_parse_record_header(double *eph, char *buf, const size_t len);
+size_t pony_gnss_io_rinex_eph_file_parse_record_lines(double *eph,  FILE *fp, char *buf, const size_t lines);
+
+	// service routines
+void   pony_gnss_io_rinex_free_null(void **ptr); // free memory with NULL-check and NULL-assignment
+	   
+void   pony_gnss_io_rinex_drop_flags_pony_sats(pony_gnss_sat *sat, const size_t sat_count, const size_t obs_count);
+void   pony_gnss_io_rinex_drop_flags_pony_sol(pony_sol *sol);
+	   
+void   pony_gnss_io_rinex_charrep(char *s, char oldc, char newc);
+char   pony_gnss_io_rinex_read_token_str(char *value,  const char *token, const char *src, const size_t len);
+char   pony_gnss_io_rinex_read_token_double(double *dest, const char *token, const char *src, const size_t len);
+char   pony_gnss_io_rinex_find_token(const char *token, const char *src, const size_t len);
+char   pony_gnss_io_rinex_epoch_check(pony_time_epoch *epoch);
+char   pony_gnss_io_rinex_epoch_from_array(pony_time_epoch *epoch, double *YMDhms);
+int    pony_gnss_io_rinex_resolve_2digit_year(int Y);
+double pony_gnss_io_rinex_dmod(double x, double y);
+
+
+
+
+
+
+
+
+
+
+
+
+
+// plugin definitions
+
+/* pony_gnss_io_rinex_v3_read_obs_from_file - pony plugin
+	
+	Reads observation data (measurements) from RINEX v3.0x files, including header and data records.
+	Supports GPS, GLONASS, Galileo and BeiDou systems.
+	Multi-receiver/multi-antenna capable, with syncronization option.
+	Does not support header updates after END OF HEADER line.
+	Only limited number of header labels are processed. 
+
+	description:
+		supported header labels are
+			- required
+				RINEX VERSION / TYPE
+				SYS / # / OBS TYPES
+				TIME OF FIRST OBS
+				END OF HEADER
+			- optional
+				GLONASS SLOT / FRQ #
+				LEAP SECONDS	
+	uses:
+		pony->gnss_count
+		pony->gnss[].gps/glo/gal/bds->max_sat_count
+	changes:
+		pony->mode
+		pony->gnss[].epoch
+		pony->gnss[].leap_sec
+		pony->gnss[].leap_sec_valid
+		pony->gnss[].gps/glo/gal/bds->obs_count
+		pony->gnss[].gps/glo/gal/bds->obs_types
+		pony->gnss[].gps/glo/gal/bds->sat[]. obs
+		pony->gnss[].gps/glo/gal/bds->sat[]. obs_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].t_em_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].   x_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].   v_valid
+		pony->gnss[].glo->freq_slot
+		pony->gnss[].sol.  x_valid
+		pony->gnss[].sol.llh_valid
+		pony->gnss[].sol.  v_valid
+		pony->gnss[].sol.  q_valid
+		pony->gnss[].sol.  L_valid
+		pony->gnss[].sol.rpy_valid
+		pony->gnss[].sol. dt_valid
+	cfg parameters:
+		{gnss: obs_in} - gnss rinex observation data input source
+			type   : string
+			range  : valid file name
+			default: none
+			example: {gnss: obs_in = "data/191025_0255/191025_0255_rover.19o"}
+		gnss_sync - multi-receiver observations synchronization threshold, sec
+			type   : float
+			range  : >0
+			default: none
+			example: gnss_sync = 0.09
+			negative values result in sync turned off
+*/
+void pony_gnss_io_rinex_v3_read_obs_from_file(void) {
+
+	const char 
+		cfg_obs_token  [] = "obs_in",    // gnss rinex observation data input source              parameter name in configuration
+		gnss_sync_token[] = "gnss_sync"; // multi-receiver observations synchronization threshold parameter name in configuration
+	
+	static FILE   **fp        = NULL;    // file pointers for each receiver
+	static char   **buf       = NULL;    // data buffers  for each receiver
+	static double   gnss_sync = -1;      // multi-receiver observations synchronization threshold in seconds, negative for sync off
+
+	size_t          r, count;                     // common counting variables
+	pony_time_epoch latest_epoch = {0,0,0,0,0,0}; // latest epoch to sync
+
+	// requires gnss data initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0)	{
+
+		// allocate memory
+		fp	= (FILE **)calloc( pony->gnss_count, sizeof(FILE *) );
+		buf	= (char **)calloc( pony->gnss_count, sizeof(char *) );
+		if (fp == NULL || buf == NULL) {
+			printf("\nERROR: memory allocation failed for rinex observation data");
+			pony->mode = -1;
+			return;
+		}
+		// initialize data for each receiver
+		for (r = 0; r < pony->gnss_count; r++) {
+
+			// initialize file pointer
+			fp[r] = NULL;
+			// requires gnss data initialized for current receiver
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			// allocate data buffer
+			buf[r] = (char *)calloc( PONY_GNSS_IO_RINEX_BUFFER_SIZE, sizeof(char) );
+			if (buf[r] == NULL) {
+				printf("\nERROR: memory allocation failed for rinex observation data buffers");
+				pony->mode = -1;
+				return;
+			}
+			// observation file name from configuration
+			if (  !pony_gnss_io_rinex_read_token_str(buf[r],  cfg_obs_token, pony->gnss[r].cfg_settings, pony->gnss[r].settings_length) 
+				|| buf[r][0] == '\0' ) {
+				printf("\n\tERROR: could not find GNSS observations RINEX file name in the configuration for gnss[%d]:\n\t\t'%s'",
+					r, pony->gnss[r].cfg_settings);
+				pony->mode = -1;
+				return;
+			}
+			// open the file
+			fp[r] = fopen(buf[r],"r");
+			if (fp[r] == NULL) {
+				printf("\n\terror: could not open GNSS observations RINEX file '%s' for gnss[%d]",buf[r],r);
+				pony->mode = -1;
+				return;
+			}
+			printf("\n\t'%s' opened",buf[r]);
+			// read RINEX header
+			if ( !pony_gnss_io_rinex_v3_obs_file_header_read(&(pony->gnss[r]), fp[r], buf[r]) ) {
+				printf("\n\tERROR: GNSS observations RINEX file header not parsed for gnss[%d]", r);
+				pony->mode = -1;
+				return;
+			}
+
+		}
+
+		// check for gnss_sync option
+		if ( pony_gnss_io_rinex_read_token_double(&gnss_sync, gnss_sync_token, pony->cfg_settings, pony->settings_length)
+			&& gnss_sync > 0)
+			printf("\n\n\t GNSS observations will be synchronized by time of day within %.3f msec to the latest one\n", gnss_sync*1e3);
+		else
+			gnss_sync = -1;
+
+		// no return, try to read the first observation chunk in RINEX records
+	}
+
+	// terminate
+	if (pony->mode < 0)	{
+
+		// close files, if not yet
+		if (fp != NULL) {
+			for (r = 0; r < pony->gnss_count; r++)
+				if (pony->gnss[r].cfg == NULL)
+					continue;
+				else if (fp[r] != NULL)
+					fclose(fp[r]);
+			free(fp);
+			fp = NULL;
+		}
+		// free memory
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			pony_gnss_io_rinex_free_null( (void **)(&(buf[r])) );
+		}
+		pony_gnss_io_rinex_free_null( (void **)(&buf) );
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+
+		// try to parse data records for all available receivers, count total measurements
+		for (r = 0, count = 0; r < pony->gnss_count; r++)
+			if (fp[r] == NULL)
+				continue;
+			else
+				count += pony_gnss_io_rinex_v3_obs_file_record_read(&(pony->gnss[r]), fp[r], buf[r]);
+		if (!count) // no single measurement parsed
+			pony->mode = -1;
+		// epoch synchronization
+		if (gnss_sync <= 0) // no observation time skew check
+			return;
+		// try to synchronize observations
+			// look for the latest epoch in all available receivers
+		for (r = 0; r < pony->gnss_count; r++)
+			if (fp[r] == NULL)
+				continue;
+			else if (pony_time_epochs_compare(&latest_epoch, &(pony->gnss[r].epoch)) == -1)
+				latest_epoch = pony->gnss[r].epoch;
+			// for receivers falling behind, read succeeding records
+		for (r = 0; r < pony->gnss_count; r++)
+			if (fp[r] == NULL)
+				continue;
+			else
+				while ( 
+					pony_gnss_io_rinex_dmod(
+						(latest_epoch.h*3600+latest_epoch.m*60+latest_epoch.s) -                          // latest epoch time of day
+						(pony->gnss[r].epoch.h*3600+pony->gnss[r].epoch.m*60+pony->gnss[r].epoch.s),      // receiver epoch time of day
+						pony->gnss_const.sec_in_d)                                                        // modulo 86400 (seconds in a day)
+						>
+						gnss_sync )
+					if ( !pony_gnss_io_rinex_v3_obs_file_record_read(&(pony->gnss[r]), fp[r], buf[r]) ) { // read next observation data record
+						pony->mode = -1;
+						break;
+					}
+		
+	}
+
+}
+
+/* pony_gnss_io_rinex_read_eph_from_file - pony plugin
+	
+	Reads navigation data (ephemeris) from RINEX v2-3 files, including header and data records.
+	Supports GPS, GLONASS, Galileo and BeiDou systems.
+	Multi-receiver/multi-antenna capable.
+	Does not support header updates after END OF HEADER line.
+	Only limited number of header labels are processed.
+
+	description:
+		supported header labels are
+			- mandatory
+				RINEX VERSION / TYPE
+				END OF HEADER
+			- optional
+				IONOSPHERIC CORR
+				TIME SYSTEM CORR
+				LEAP SECONDS
+	uses:
+		pony->gnss_count
+		pony->gnss[].gps/glo/gal/bds->max_eph_count
+		pony->gnss[].gps/glo/gal/bds->max_sat_count
+	changes:
+		pony->mode
+		pony->gnss[].leap_sec
+		pony->gnss[].leap_sec_valid
+		pony->gnss[].gps/bds->iono_a
+		pony->gnss[].gps/bds->iono_b
+		pony->gnss[].gal->iono
+		pony->gnss[].gps/gal/bds->iono_valid
+		pony->gnss[].gps/glo/gal/bds->clock_corr
+		pony->gnss[].gps/glo/gal/bds->clock_corr_to
+		pony->gnss[].gps/glo/gal/bds->clock_corr_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].eph
+		pony->gnss[].gps/glo/gal/bds->sat[].eph_valid
+	cfg parameters:
+		{gnss:       eph_in } - gnss rinex mixed navigation data input source
+		and/or
+		{gnss: {gps: eph_in}} - gnss rinex gps     navigation data input source
+		and/or
+		{gnss: {glo: eph_in}} - gnss rinex glonass navigation data input source
+		and/or
+		{gnss: {gal: eph_in}} - gnss rinex galileo navigation data input source
+		and/or
+		{gnss: {bds: eph_in}} - gnss rinex beidou  navigation data input source
+			type   : string
+			range  : valid file name
+			default: none
+			example: {gnss: eph_in = "data/191025_0255/191025_0255_rover.19n"}
+			         {gnss: {gps: eph_in = "data/191025_0255/191025_0255_rover.19n"}}
+			         {gnss: {glo: eph_in = "data/191025_0255/191025_0255_rover.19r"}}
+			         {gnss: {gal: eph_in = "data/191025_0255/191025_0255_rover.19e"}}
+			         {gnss: {bds: eph_in = "data/191025_0255/191025_0255_rover.19c"}}
+*/
+void pony_gnss_io_rinex_read_eph_from_file(void) {
+
+	enum sys_index {gps, glo, gal, bds, sys_count};
+	const char cfg_eph_token[] = "eph_in";
+	
+	static FILE         ***fp            = NULL; // file pointer for each receiver for each system (for mixed rinex files only one is used per receiver)
+	static char         ***buf           = NULL; // reading buffer for each receiver for each system (for mixed rinex files only one is used per receiver)
+	static double       ***eph           = NULL; // latest ephemeris set parsed for each receiver for each system
+	static unsigned int  **sn            = NULL; // current satellite number for each receiver for each system
+	static size_t         *max_eph_count = NULL; // maximum number of ephemeris for each system
+	static size_t         *max_sat_count = NULL; // maximum number of satellites for each system
+
+	char 
+		fname [PONY_GNSS_IO_RINEX_BUFFER_SIZE] = "", // system-specific file name, if found in configuration
+		fname0[PONY_GNSS_IO_RINEX_BUFFER_SIZE] = ""; // mixed data file name,      if found in configuration
+	pony_gnss_sat *sat;    // pointer to particular satellite data
+	size_t         r, sys; // receiver and system index variables
+
+	// requires gnss data initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0)	{
+
+		// determine maximum number of ephemeris and satellites
+		max_eph_count = (size_t *)calloc( sys_count, sizeof(size_t) );
+		max_sat_count = (size_t *)calloc( sys_count, sizeof(size_t) );
+		for (r = 0; r < pony->gnss_count; r++) {
+			// skip if current receiver uninitialized
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			if (pony->gnss[r].gps != NULL) { // for gps system
+				if (pony->gnss[r].gps->max_eph_count > max_eph_count[gps]) max_eph_count[gps] = pony->gnss[r].gps->max_eph_count;
+				if (pony->gnss[r].gps->max_sat_count > max_sat_count[gps]) max_sat_count[gps] = pony->gnss[r].gps->max_sat_count;
+			}
+			if (pony->gnss[r].glo != NULL) { // for glonass system
+				if (pony->gnss[r].glo->max_eph_count > max_eph_count[glo]) max_eph_count[glo] = pony->gnss[r].glo->max_eph_count;
+				if (pony->gnss[r].glo->max_sat_count > max_sat_count[glo]) max_sat_count[glo] = pony->gnss[r].glo->max_sat_count;
+			}
+			if (pony->gnss[r].gal != NULL) { // for galileo system
+				if (pony->gnss[r].gal->max_eph_count > max_eph_count[gal]) max_eph_count[gal] = pony->gnss[r].gal->max_eph_count;
+				if (pony->gnss[r].gal->max_sat_count > max_sat_count[gal]) max_sat_count[gal] = pony->gnss[r].gal->max_sat_count;
+			}
+			if (pony->gnss[r].bds != NULL) { // for beidou system
+				if (pony->gnss[r].bds->max_eph_count > max_eph_count[bds]) max_eph_count[bds] = pony->gnss[r].bds->max_eph_count;
+				if (pony->gnss[r].bds->max_sat_count > max_sat_count[bds]) max_sat_count[bds] = pony->gnss[r].bds->max_sat_count;
+			}
+		}
+		// check if at least one system initialized
+		for (sys = 0; sys < sys_count; sys++)
+			if (max_eph_count[sys] > 0)
+				break;
+		if (sys == sys_count) // neither GPS, GLONASS, Galileo or BeiDou data initialized on the bus
+			return; 
+		// allocate buffers for receivers
+		eph = (double      ***)calloc( pony->gnss_count, sizeof(double      **) );
+		fp  = (FILE        ***)calloc( pony->gnss_count, sizeof(FILE        **) );
+		buf = (char        ***)calloc( pony->gnss_count, sizeof(char        **) );
+		sn  = (unsigned int **)calloc( pony->gnss_count, sizeof(unsigned int *) );
+		if (eph == NULL || fp == NULL || buf == NULL || sn == NULL) {
+			printf("\nERROR: memory allocation failed for rinex ephemeris data");
+			pony->mode = -1;
+			return;
+		}
+		// initialize data for each receiver
+		for (r = 0; r < pony->gnss_count; r++) {
+			// initialize file pointer
+			fp[r] = NULL;
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			// allocate variables for each supported system
+			fp [r] = (FILE         **)calloc( sys_count, sizeof(FILE       *) ); 
+			buf[r] = (char         **)calloc( sys_count, sizeof(char       *) ); 
+			sn [r] = (unsigned int  *)calloc( sys_count, sizeof(unsigned int) );
+			eph[r] = (double       **)calloc( sys_count, sizeof(double     *) );
+			if (fp[r] == NULL || buf[r] == NULL || sn[r] == NULL || eph[r] == NULL) {
+				printf("\nERROR: memory allocation failed for rinex ephemeris receiver data");
+				pony->mode = -1;
+				return;
+			}
+			for (sys = 0; sys < sys_count; sys++) {
+				eph[r][sys] = (double *)calloc( max_eph_count[sys], sizeof(double) );
+				if (eph[r][sys] == NULL && max_eph_count[sys] > 0) {
+					printf("\nERROR: memory allocation failed for rinex ephemeris gnss system data");
+					pony->mode = -1;
+					return;
+				}
+			}		
+			// determine files from configuration
+				// check for a mixed multi-gnss file
+			pony_gnss_io_rinex_read_token_str(fname0,  cfg_eph_token, pony->gnss[r].cfg_settings, pony->gnss[r].settings_length); 	
+				// gps
+			fp[r][gps] = NULL;
+			if (pony->gnss[r].gps != NULL) // look for navigation data file for gps
+				if ( pony_gnss_io_rinex_read_token_str(fname,  cfg_eph_token, pony->gnss[r].gps->cfg, pony->gnss[r].gps->cfglength) )
+					fp[r][gps] = fopen(fname , "r"); // try to open for reading
+				else
+					fp[r][gps] = fopen(fname0, "r"); // try to open for reading
+				// glonass
+			fp[r][glo] = NULL;
+			if (pony->gnss[r].glo != NULL) // look for navigation data file for glonass
+				if ( pony_gnss_io_rinex_read_token_str(fname,  cfg_eph_token, pony->gnss[r].glo->cfg, pony->gnss[r].glo->cfglength) )
+					fp[r][glo] = fopen(fname, "r"); // try to open for reading
+				else
+					fp[r][glo] = fopen(fname0, "r"); // try to open for reading
+				// galileo
+			fp[r][gal] = NULL;
+			if (pony->gnss[r].gal != NULL) // look for navigation data file for galileo
+				if ( pony_gnss_io_rinex_read_token_str(fname,  cfg_eph_token, pony->gnss[r].gal->cfg, pony->gnss[r].gal->cfglength) )
+					fp[r][gal] = fopen(fname , "r"); // try to open for reading
+				else
+					fp[r][gal] = fopen(fname0, "r"); // try to open for reading
+				// beidou
+			fp[r][bds] = NULL;
+			if (pony->gnss[r].bds != NULL) // look for navigation data file for beidou
+				if ( pony_gnss_io_rinex_read_token_str(fname,  cfg_eph_token, pony->gnss[r].bds->cfg, pony->gnss[r].bds->cfglength) )
+					fp[r][bds] = fopen(fname, "r"); // try to open for reading
+				else
+					fp[r][bds] = fopen(fname0, "r"); // try to open for reading
+				// check for required files found
+			if (    (pony->gnss[r].gps != NULL && fp[r][gps] == NULL) 
+				 || (pony->gnss[r].glo != NULL && fp[r][glo] == NULL) 
+				 || (pony->gnss[r].gal != NULL && fp[r][gal] == NULL)
+				 || (pony->gnss[r].bds != NULL && fp[r][bds] == NULL) ) { // at least one of required ephemeris file does not exist
+						printf("\n\tERROR: failed to get all required ephemeris RINEX files from configuration for gnss[%d]:\n\t\t'%s'",
+							r, pony->gnss[r].cfg_settings);
+						pony->mode = -1;
+						return;
+					}
+			// allocate buffers and read RINEX headers
+			for (sys = 0; sys < sys_count; sys++) {
+				// skip unopened files
+				if (fp[r][sys] == NULL)
+					continue;
+				// memory buffer
+				buf[r][sys] = (char *)calloc( PONY_GNSS_IO_RINEX_BUFFER_SIZE, sizeof(char) );
+				if (buf[r][sys] == NULL) {
+					printf("\nERROR: memory allocation failed for rinex ephemeris data buffer");
+					pony->mode = -1;
+					return;
+				}
+				// parse navigation data header
+				if ( !pony_gnss_io_rinex_eph_file_header_read(&(pony->gnss[r]), fp[r][sys], buf[r][sys]) ) {
+					printf("\n\tERROR: ephemeris RINEX file header not parsed for gnss[%d]", r);
+					pony->mode = -1;
+					return;
+				}
+			}
+
+		}
+
+	}
+
+	// terminate
+	if (pony->mode < 0)	{
+
+		// close files and free memory, if not already
+		if (fp != NULL) {
+			// for each receiver
+			for (r = 0; r < pony->gnss_count; r++) {
+				// skip uninitialized
+				if (fp[r] == NULL)
+					continue;
+				// for each system
+				for (sys = 0; sys < sys_count; sys++) {
+					if (fp[r][sys] == NULL) 
+						continue; 
+					fclose(fp[r][sys]);
+					fp[r][sys] = NULL;
+				}
+				free(fp[r]);
+				fp[r] = NULL;
+			}
+			free(fp);
+			fp = NULL;
+		}
+		// free memory
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			if (sn != NULL)
+				pony_gnss_io_rinex_free_null( (void **)(&(sn[r])) );
+			if (eph != NULL && eph[r] != NULL) {
+				for (sys = 0; sys < sys_count; sys++)
+					pony_gnss_io_rinex_free_null( (void **)(&(eph[r][sys])) );
+				pony_gnss_io_rinex_free_null( (void **)(&(eph[r])) );
+			}
+			if (buf != NULL && buf[r] != NULL) {
+				for (sys = 0; sys < sys_count; sys++)
+					pony_gnss_io_rinex_free_null( (void **)(&(buf[r][sys])) );
+				pony_gnss_io_rinex_free_null( (void **)(&(buf[r])) );
+			}
+		}
+		pony_gnss_io_rinex_free_null( (void **)(&sn				) );
+		pony_gnss_io_rinex_free_null( (void **)(&eph			) );
+		pony_gnss_io_rinex_free_null( (void **)(&buf			) );
+		pony_gnss_io_rinex_free_null( (void **)(&max_eph_count	) );
+		pony_gnss_io_rinex_free_null( (void **)(&max_sat_count	) );
+
+	}
+
+	// regular processing
+	else {
+		// for each receiver
+		for (r = 0; r < pony->gnss_count; r++)
+			// skip uninitialized
+			if (fp[r] != NULL)
+				// for each system
+				for (sys = 0; sys < sys_count; sys++)
+					// skip uninitialized
+					if (fp[r][sys] != NULL) {
+						// assign pointers
+						sat = NULL;
+						switch (sys) {
+							case gps:
+								if (pony->gnss[r].gps != NULL) 
+									sat = pony->gnss[r].gps->sat; 
+								else
+									continue;
+								break;
+							case glo:
+								if (pony->gnss[r].glo != NULL) 
+									sat = pony->gnss[r].glo->sat; 
+								else
+									continue;
+								break;
+							case gal:
+								if (pony->gnss[r].gal != NULL) 
+									sat = pony->gnss[r].gal->sat; 
+								else
+									continue;
+								break;
+							case bds:
+								if (pony->gnss[r].bds != NULL) 
+									sat = pony->gnss[r].bds->sat; 
+								else
+									continue;
+								break;
+							default:
+								continue;
+						}
+						// parse records from file
+						pony_gnss_io_rinex_eph_file_records_read(
+							sat, &(pony->gnss[r].epoch), 
+							fp[r][sys], buf[r][sys], eph[r][sys], &(sn[r][sys]), 
+							sys, max_sat_count[sys], max_eph_count[sys]);
+					}
+	}
+
+}
+
+
+
+
+
+
+
+
+// internal routines
+	// RINEX routines
+		// observation file header
+char pony_gnss_io_rinex_v3_obs_file_header_read(pony_gnss *gnss, FILE *fp, char *buf) {
+
+	const size_t label_offset = 61, label_len = 20;
+	const char 
+		gps_sys_id[] = "G",
+		glo_sys_id[] = "R",
+		gal_sys_id[] = "E",
+		bds_sys_id[] = "C";
+
+	// required token - version and type
+	const char rinex_version_type_label[] = "RINEX VERSION / TYPE";
+	const float rinex_version_range[] = {3.02f, 3.04f};
+	const float rinex_version_prec = 0.001f;
+	const char rinex_type_token = 'O';
+
+	// required token - system & observation types
+	const char rinex_sys_obstypes_label[] = "SYS / # / OBS TYPES";
+	// required token - time of 1st observation
+	const char rinex_TOFO_label[] = "TIME OF FIRST OBS";
+	// required token - end of header
+	const char rinex_EOH_label[] = "END OF HEADER"  ;
+
+	const size_t tokens_required = 4;
+
+	// optional token - glonass slot frequencies
+	const char rinex_glo_freq_slot[] = "GLONASS SLOT / FRQ #";
+	// optional token - leap seconds
+	const char rinex_leap_sec[] = "LEAP SECONDS";
+
+	size_t tokens_found = 0;
+	float version;
+	size_t i;
+	int scanned;
+	char current_sys = 0, sys_obstypes_found = 0, glo_freq_slot_found = 0;
+
+
+
+	if ( feof(fp) )
+		return 0;
+
+	// check tokens
+	while ( !feof(fp) ) {
+
+		// read a new string
+		fgets(buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE, fp);
+		for (i = 0; buf[i] >= ' '; i++); buf[i] = '\0';		// set end of line on the first non-printable character
+		if (i < label_offset) continue;						// check if buffer contains enough characters to proceed
+
+		// check if a starting token is found
+		if ( pony_gnss_io_rinex_find_token(rinex_version_type_label,buf+label_offset-1,label_len) ) {
+			printf("\n\t\t%s",buf);
+			if (sscanf(buf,"%f %s",&version,buf) < 2) {
+				printf("\n\t\terror: RINEX header line %s not parsed from %s", rinex_version_type_label, buf);
+				return 0;
+			}
+			if (version+rinex_version_prec < rinex_version_range[0] || rinex_version_range[1] < version-rinex_version_prec) {
+				printf("\n\t\terror: RINEX version out of range: header contains %f, must be from %f to %f", version, rinex_version_range[0], rinex_version_range[1]);
+				return 0;
+			}
+			if (buf[0] != rinex_type_token) {
+				printf("\n\t\terror: RINEX observation file type incorrect: %s, must start with '%c'", buf, rinex_type_token);
+				return 0;
+			}
+			tokens_found++;
+			break;
+		}
+	}
+
+	while ( !feof(fp) ) {
+
+		fgets(buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE, fp);
+		for (i = 0; buf[i] >= ' '; i++); buf[i] = '\0';		// set end of line on the first non-printable character
+		if (i < label_offset) continue;						// check if buffer contains enough characters to proceed
+
+		// check if a token is found
+		if ( pony_gnss_io_rinex_find_token(rinex_sys_obstypes_label,buf+label_offset-1,label_len) ) {
+			printf("\n\t\t%s",buf);
+
+			if (!sys_obstypes_found) {
+				tokens_found++;
+				sys_obstypes_found = 1;
+			}
+			
+			for (i = 0; buf[i] && buf[i] <= ' ' &&  i < label_offset-1; i++); // skip all non-printable
+			// check for GPS system id, if initialized on the bus
+			if ( gnss->gps != NULL && pony_gnss_io_rinex_find_token(gps_sys_id,buf+i,label_offset-i) ) {
+				current_sys = gps_sys_id[0];
+				if ( !pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->gps->obs_count), &(gnss->gps->obs_types), gnss->gps->sat,  buf + i, label_offset-1-i, gnss->gps->max_sat_count, 0) ) {
+					printf("\n\t\terror: RINEX observation types not parsed in header from %s", buf);
+					return 0;
+				}
+				continue;
+			}
+			// check for GLONASS system id, if initialized on the bus
+			if ( gnss->glo != NULL && pony_gnss_io_rinex_find_token(glo_sys_id,buf + i,label_offset-i) ) {
+				current_sys = glo_sys_id[0];
+
+				if ( !pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->glo->obs_count), &(gnss->glo->obs_types), gnss->glo->sat,  buf + i, label_offset-1-i, gnss->glo->max_sat_count, 0) ) {
+					printf("\n\t\terror: RINEX observation types not parsed in header from %s", buf);
+					return 0;
+				}
+				continue;
+			}
+			// check for Galileo system id, if initialized on the bus
+			if ( gnss->gal != NULL && pony_gnss_io_rinex_find_token(gal_sys_id,buf+i,label_offset-i) ) {
+				current_sys = gal_sys_id[0];
+				if ( !pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->gal->obs_count), &(gnss->gal->obs_types), gnss->gal->sat,  buf + i, label_offset-1-i, gnss->gal->max_sat_count, 0) ) {
+					printf("\n\t\terror: RINEX observation types not parsed in header from %s", buf);
+					return 0;
+				}
+				continue;
+			}
+			// check for BeiDou system id, if initialized on the bus
+			if ( gnss->bds != NULL && pony_gnss_io_rinex_find_token(bds_sys_id,buf+i,label_offset-i) ) {
+				current_sys = bds_sys_id[0];
+				if ( !pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->bds->obs_count), &(gnss->bds->obs_types), gnss->bds->sat,  buf + i, label_offset-1-i, gnss->bds->max_sat_count, 0) ) {
+					printf("\n\t\terror: RINEX observation types not parsed in header from %s", buf);
+					return 0;
+				}
+				continue;
+			}
+			// proceed with the current system, if present
+			if (current_sys == gps_sys_id[0])
+				pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->gps->obs_count), &(gnss->gps->obs_types), gnss->gps->sat,  buf + i, label_offset-1-i, gnss->gps->max_sat_count, 1);
+			if (current_sys == glo_sys_id[0])
+				pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->glo->obs_count), &(gnss->glo->obs_types), gnss->glo->sat,  buf + i, label_offset-1-i, gnss->glo->max_sat_count, 1);
+			if (current_sys == gal_sys_id[0])
+				pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->gal->obs_count), &(gnss->gal->obs_types), gnss->gal->sat,  buf + i, label_offset-1-i, gnss->gal->max_sat_count, 1);
+			if (current_sys == bds_sys_id[0])
+				pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(&(gnss->bds->obs_count), &(gnss->bds->obs_types), gnss->bds->sat,  buf + i, label_offset-1-i, gnss->bds->max_sat_count, 1);
+			continue;
+		}
+
+		// check if a token is found
+		if ( pony_gnss_io_rinex_find_token(rinex_glo_freq_slot,buf+label_offset-1,label_len) && gnss->glo != NULL) {
+			printf("\n\t\t%s",buf);
+			if (!glo_freq_slot_found) {
+				if ( !pony_gnss_io_rinex_obs_file_header_parse_glo_slot_frq(gnss->glo,  buf, label_offset-1, 0) )
+					printf("\n\t\twarning: RINEX glonass frequency slots not parsed in header from %s\n", buf);
+				glo_freq_slot_found = 1;
+			}
+			else
+				if ( !pony_gnss_io_rinex_obs_file_header_parse_glo_slot_frq(gnss->glo,  buf, label_offset-1, 1) )
+					printf("\n\t\twarning: RINEX glonass frequency slots not parsed in header from %s\n", buf);
+			continue;
+		}
+
+		// check if a token is found
+		if ( pony_gnss_io_rinex_find_token(rinex_TOFO_label,buf+label_offset-1,label_len) ) {
+			printf("\n\t\t%s",buf);
+
+			scanned = sscanf( buf,"%d %d %d %d %d %lf",
+				&(gnss->epoch.Y),&(gnss->epoch.M),&(gnss->epoch.D),
+				&(gnss->epoch.h),&(gnss->epoch.m),&(gnss->epoch.s) );
+			if ( scanned < 6 || !pony_gnss_io_rinex_epoch_check( &(gnss->epoch) ) ) {
+				printf("\n\t\terror: RINEX time of first observation not parsed in header from %s", buf);
+				return 0;
+			}
+			gnss->epoch.Y = pony_gnss_io_rinex_resolve_2digit_year(gnss->epoch.Y);
+
+			tokens_found++;
+			continue;
+		}
+
+		// check if a token is found
+		gnss->leap_sec = 18; // default value as for 2019-DEC
+		gnss->leap_sec_valid = 1;
+		if ( pony_gnss_io_rinex_find_token(rinex_leap_sec,buf+label_offset-1,label_len) ) {
+			printf("\n\t\t%s",buf);
+			if ( !pony_gnss_io_rinex_file_header_parse_leap_sec(gnss, buf, label_offset-1) )
+				printf("\n\t\twarning: leap seconds not parsed from '%s'",buf);
+			continue;
+		}
+
+		// check if end of header token is found
+		if ( pony_gnss_io_rinex_find_token(rinex_EOH_label,buf+label_offset-1,label_len) ) {
+			printf("\n\t\t%s",buf);
+			tokens_found++;
+			break;
+		}
+
+	}
+
+	return (tokens_found == tokens_required)? 1 : 0;
+}
+
+	// observation file header line sys/obstypes
+char pony_gnss_io_rinex_obs_file_header_parse_sys_obstypes(size_t *obs_count, char (**obs_types)[4], pony_gnss_sat *sat,  char *buf, const size_t len, const size_t sat_count, char flag) {
+
+	const size_t obstype_length = 3;
+
+	static unsigned int current_sys_obs_count = 0, current_sys_obs_index = 0;
+
+	size_t i, j, n;
+	int scanned;
+
+	for (n = 0; n < len && buf[n]; n++);
+	i = 0;
+	switch (flag) {
+
+		case 0: // starting entries
+
+			for (; i < n &&           buf[i] >  ' '; i++); // skip all     printable
+			for (; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+
+			// observation count
+				// parse the number
+			scanned = sscanf(buf + i, "%u", &current_sys_obs_count);
+			if (scanned < 1 || current_sys_obs_count == 0) 
+				return 0;
+			*obs_count = current_sys_obs_count;
+				// allocate memory for observations & validity flags
+			for (j = 0; j < sat_count; j++) {
+				sat[j].obs			= (double *)calloc( *obs_count, sizeof(double) );
+				sat[j].obs_valid	= (char   *)calloc( *obs_count, sizeof(char  ) );
+				if (sat[j].obs == NULL || sat[j].obs_valid == NULL)
+					return 0;
+			}
+				// allocate memory for observation types
+			*obs_types = (char (*)[4])calloc( *obs_count, sizeof(char [4]) );
+			if (*obs_types == NULL)
+				return 0;
+			current_sys_obs_index = 0;
+
+			for (; i < n &&           buf[i] >  ' '; i++); // skip all     printable
+			for (; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+
+
+		case 1: // continuation
+
+			// parse observation types
+			for (; i < n && buf[i] && current_sys_obs_index < *obs_count; current_sys_obs_index++) {
+				for (j = 0; i < n && buf[i] > ' ' && j < obstype_length; i++, j++)
+					(*obs_types)[current_sys_obs_index][j] = buf[i];
+
+				for (; i < n &&           buf[i] >  ' '; i++); // skip all     printable
+				for (; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+			}
+
+	}
+
+	return 1;
+}
+
+	// observation file header line glonass slot/frq #
+char pony_gnss_io_rinex_obs_file_header_parse_glo_slot_frq(pony_gnss_glo *glo,  char *buf, const size_t len, char flag) {
+
+	const int max_frq_num = 24;
+
+	static unsigned int entry_count = 0, current_entry_index = 0;
+
+	size_t i, n;
+	unsigned int sn;
+	int scanned;
+
+	for (n = 0; n < len && buf[n]; n++);
+	for (i = 0; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+	switch (flag) {
+
+		case 0: // starting entries
+
+			// entry count
+				// parse the number
+			scanned = sscanf(buf + i, "%u", &entry_count);
+			if (scanned < 1 || entry_count == 0 || entry_count > glo->max_sat_count) 
+				return 0;
+			current_entry_index = 0;
+
+			for (; i < n &&           buf[i] >  ' '; i++); // skip all     printable
+			for (; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+
+
+		case 1: // continuation
+
+			// parse glonass frequency slots
+			for (; i < n && buf[i] && current_entry_index < entry_count; current_entry_index++) {
+				scanned = sscanf(buf+i, "%*c%u", &sn);
+				if (scanned < 1 || sn == 0 || sn > glo->max_sat_count)
+					return 0;
+
+				for (; i < n &&           buf[i] >  ' '; i++); // skip all     printable
+				for (; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+
+				scanned = sscanf( buf+i, "%d", &(glo->freq_slot[sn-1]) );
+				if (scanned < 1 || abs(glo->freq_slot[sn-1]) > max_frq_num )
+					return 0;
+
+				for (; i < n &&           buf[i] >  ' '; i++); // skip all     printable
+				for (; i < n && buf[i] && buf[i] <= ' '; i++); // skip all non-printable
+			}
+
+	}
+
+	return 1;
+
+}
+
+	// observation file records
+char pony_gnss_io_rinex_v3_obs_file_record_read(pony_gnss *gnss, FILE *fp, char *buf) {
+
+	const char 
+		gps_sys_id[] = "G",
+		glo_sys_id[] = "R",
+		gal_sys_id[] = "E",
+		bds_sys_id[] = "C",
+		rec_id = '>';
+
+	int epoch_flag = -1, scanned;
+	unsigned int i, n = 0;
+
+	if (gnss == NULL || fp == NULL || buf == NULL || gnss->cfg == NULL)
+		return 0;
+
+	// wait for the record identifier to occur
+	do
+		fgets(buf,PONY_GNSS_IO_RINEX_BUFFER_SIZE,fp);
+	while (!feof(fp) && buf[0] != rec_id);
+
+	if ( feof(fp) )
+		return 0;
+
+	scanned = sscanf(buf, "%*c %d %d %d  %d %d %lf  %d  %u", 
+		&(gnss->epoch.Y), &(gnss->epoch.M), &(gnss->epoch.D),
+		&(gnss->epoch.h), &(gnss->epoch.m), &(gnss->epoch.s),
+		&epoch_flag, &n);
+
+	if (scanned < 8 || !pony_gnss_io_rinex_epoch_check( &(gnss->epoch) ) || epoch_flag) {
+		printf("\n\t\terror: RINEX observation record not parsed at %s", buf);
+		return 0;
+	}
+
+	// if a new epoch has come, all observations and satellite data became outdated, drop their validity
+	if (gnss->gps != NULL)
+		pony_gnss_io_rinex_drop_flags_pony_sats(gnss->gps->sat, gnss->gps->max_sat_count, gnss->gps->obs_count); // GPS satellite flags
+	if (gnss->glo != NULL)
+		pony_gnss_io_rinex_drop_flags_pony_sats(gnss->glo->sat, gnss->glo->max_sat_count, gnss->glo->obs_count); // GLONASS satellite flags
+	if (gnss->gal != NULL)
+		pony_gnss_io_rinex_drop_flags_pony_sats(gnss->gal->sat, gnss->gal->max_sat_count, gnss->gal->obs_count); // Galileo satellite flags
+	if (gnss->bds != NULL)
+		pony_gnss_io_rinex_drop_flags_pony_sats(gnss->bds->sat, gnss->bds->max_sat_count, gnss->bds->obs_count); // BeiDou satellite flags
+	pony_gnss_io_rinex_drop_flags_pony_sol( &(gnss->sol) ); // solution flags
+
+	for (i = 0; i < n && !feof(fp); i++) {
+		fgets(buf,PONY_GNSS_IO_RINEX_BUFFER_SIZE,fp);
+
+		if      (buf[0] == gps_sys_id[0] && gnss->gps != NULL 
+			&& !pony_gnss_io_rinex_obs_file_record_parse_obs_line(gnss->gps->sat,  buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE, gnss->gps->max_sat_count, gnss->gps->obs_count) )
+				break;
+		else if (buf[0] == glo_sys_id[0] && gnss->glo != NULL
+			&& !pony_gnss_io_rinex_obs_file_record_parse_obs_line(gnss->glo->sat,  buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE, gnss->glo->max_sat_count, gnss->glo->obs_count) )
+				break;
+		else if (buf[0] == gal_sys_id[0] && gnss->gal != NULL 
+			&& !pony_gnss_io_rinex_obs_file_record_parse_obs_line(gnss->gal->sat,  buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE, gnss->gal->max_sat_count, gnss->gal->obs_count) )
+				break;
+		else if (buf[0] == bds_sys_id[0] && gnss->bds != NULL 
+			&& !pony_gnss_io_rinex_obs_file_record_parse_obs_line(gnss->bds->sat,  buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE, gnss->bds->max_sat_count, gnss->bds->obs_count) )
+				break;
+		else
+			continue;
+
+	}
+	if (i < n) // not enough satellite data collected
+		return 0;
+
+	return 1;
+}
+
+char pony_gnss_io_rinex_obs_file_record_parse_obs_line(pony_gnss_sat *sat,  char *buf, const size_t len, const size_t sat_count, const size_t obs_count) {
+
+	const size_t obs_width = 14,	LLI_width = 1,		SS_width = 1,		rec_width = obs_width+LLI_width+SS_width, sat_id_width = 3;
+	const char	 obs_fmt[] = "%lf",	LLI_fmt[] = "%d",	SS_fmt[] = "%d";
+
+	size_t i, k, n, n1, dk;
+	unsigned int sn;
+	int scanned;
+	int LLI, SS;
+	char c;
+	
+	for (n = 0; n < len && buf[n]; n++);
+	if (n < sat_id_width)
+		return 0;
+
+	c = buf[sat_id_width];
+	buf[sat_id_width] = 0;
+	scanned = sscanf(buf, "%*c%2u", &sn);
+	buf[sat_id_width] = c;
+	if (scanned < 1 || sn == 0 || sn > sat_count)
+		return 0;
+
+	n1 = n - obs_width;
+	for (i = 0, k = sat_id_width; i < obs_count && k < n1; i++, k += rec_width) {
+		scanned = 0;
+		// parse observation field
+		scanned = pony_gnss_io_rinex_v3_obs_file_record_read_parse_entry( buf+k   , obs_width, obs_fmt, (void *)&(sat[sn-1].obs[i]) );
+		dk = obs_width;
+		if (scanned == 1)
+			sat[sn-1].obs_valid[i] = 1;
+		// parse LLI (loss of lock indicator) field
+		if (k+dk >= n)
+			break;
+		LLI = 0;
+		scanned = pony_gnss_io_rinex_v3_obs_file_record_read_parse_entry( buf+k+dk, LLI_width, LLI_fmt, (void *)&LLI );
+		dk += LLI_width;
+		if (k+dk >= n)
+			break;
+		if (scanned == 1 && LLI)
+			sat[sn-1].obs_valid[i] = 0;
+		// parse SS (signal strength) field, not analyzed yet
+		SS = 0;
+		scanned = pony_gnss_io_rinex_v3_obs_file_record_read_parse_entry( buf+k+dk, SS_width, SS_fmt, (void *)&SS );
+	}
+
+	return 1;
+
+}
+
+int pony_gnss_io_rinex_v3_obs_file_record_read_parse_entry(char *buf, const size_t width, const char *fmt, void *dest) {
+
+	char c;
+	int scanned;
+
+	c = buf[width];
+	buf[width] = '\0';
+	scanned = sscanf(buf, fmt, dest);
+	buf[width] = c;
+
+	return scanned;
+}
+
+
+	// ephemeris file header
+char pony_gnss_io_rinex_eph_file_header_read(pony_gnss *gnss, FILE *fp, char *buf) {
+
+	const size_t label_offset = 61, label_len = 20;
+
+	// mandatory tokens
+	const char rinex_version_type_token[] = "RINEX VERSION / TYPE";
+	const char rinex_type_token[] = "N:";
+	const char rinex_EOH_token [] = "END OF HEADER"  ;
+	const size_t tokens_required = 2;
+	// optional tokens
+	const char rinex_iono_corr_token[] = "IONOSPHERIC CORR";
+	const char rinex_time_corr_token[] = "TIME SYSTEM CORR";
+	const char rinex_leap_sec_token[] = "LEAP SECONDS";
+	
+	size_t i, tokens_found = 0;
+
+	if ( feof(fp) )
+		return 0;
+
+	// check starting token
+	while ( !feof(fp) ) {
+
+		fgets(buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE-1, fp);
+		for (i = 0; buf[i] >= ' '; i++); buf[i] = '\0';		// set end of line on the first non-printable character
+		if (i < label_offset) continue;						// check if buffer contains enough characters to proceed
+
+		if ( pony_gnss_io_rinex_find_token(rinex_version_type_token,buf+label_offset-1,label_len) && pony_gnss_io_rinex_find_token(rinex_type_token,buf,label_offset-1) ) {
+			printf("\n\t%s",buf);
+			tokens_found++;
+			break;
+		}
+
+	}
+
+	// check other tokens
+	while ( !feof(fp) ) {
+
+		fgets(buf, PONY_GNSS_IO_RINEX_BUFFER_SIZE-1, fp);
+		for (i = 0; buf[i] >= ' '; i++); buf[i] = '\0';		// set end of line on the first non-printable character
+		if (i < label_offset) continue;						// check if buffer contains enough characters to proceed
+
+		// check ionospheric correction
+		if ( pony_gnss_io_rinex_find_token(rinex_iono_corr_token,buf+label_offset-1,label_len) ) {
+			printf("\n\t%s",buf);
+			if ( !pony_gnss_io_rinex_eph_file_header_parse_iono_corr(gnss, buf, label_offset-1) )
+				printf("\n\t\twarning: ionospheric correction not parsed from '%s'",buf);
+			continue;
+		}
+
+		// check time system correction
+		if ( pony_gnss_io_rinex_find_token(rinex_time_corr_token,buf+label_offset-1,label_len) ) {
+			printf("\n\t%s",buf);
+			if ( !pony_gnss_io_rinex_eph_file_header_parse_time_corr(gnss, buf, label_offset-1) )
+				printf("\n\t\twarning: time system correction not parsed from '%s'",buf);
+			continue;
+		}
+
+		// check leap seconds
+		if ( pony_gnss_io_rinex_find_token(rinex_leap_sec_token,buf+label_offset-1,label_len) ) {
+			printf("\n\t%s",buf);
+			if ( !pony_gnss_io_rinex_file_header_parse_leap_sec(gnss, buf, label_offset-1) )
+				printf("\n\t\twarning: leap seconds not parsed from '%s'",buf);
+			continue;
+		}
+
+		// check end of header
+		if ( pony_gnss_io_rinex_find_token(rinex_EOH_token,buf+label_offset-1,label_len) ) {
+			printf("\n\t%s",buf);
+			tokens_found++;   
+			break;
+		}
+
+	}
+
+	return (tokens_found == tokens_required)? 1 : 0;
+
+}
+
+		// ephemeris file header ionospheric correction
+char pony_gnss_io_rinex_eph_file_header_parse_iono_corr(pony_gnss *gnss,  char *buf, const size_t len) {
+	
+	const char gpsa_id[]		= "GPSA", gpsb_id[] =	"GPSB", gal_id[] =	"GAL", bdsa_id[] =	"BDSA", bdsb_id[] =	"BDSB";
+	const size_t id_width[]		= {4,					4,					3,					4,					4};
+	const size_t field_count[]	= {4,					4,					3,					4,					4};
+	
+	if (pony_gnss_io_rinex_find_token(gpsa_id, buf, id_width[0]) && gnss->gps != NULL)
+		if ( !pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(gnss->gps->iono_a,  buf+id_width[0]+1, len-id_width[0], field_count[0]) )
+			return 0;
+	if (pony_gnss_io_rinex_find_token(gpsb_id, buf, id_width[1]) && gnss->gps != NULL)
+		if ( pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(gnss->gps->iono_b,  buf+id_width[1]+1, len-id_width[1], field_count[1]) )
+			gnss->gps->iono_valid = 1;
+		else
+			return 0;
+	if (pony_gnss_io_rinex_find_token(gal_id, buf, id_width[2]) && gnss->gal != NULL)
+		if ( pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(gnss->gal->iono,  buf+id_width[2]+1, len-id_width[2], field_count[2]) )
+			gnss->gal->iono_valid = 1;
+		else
+			return 0;
+	if (pony_gnss_io_rinex_find_token(bdsa_id, buf, id_width[0]) && gnss->bds != NULL)
+		if ( !pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(gnss->bds->iono_a,  buf+id_width[0]+1, len-id_width[0], field_count[0]) )
+			return 0;
+	if (pony_gnss_io_rinex_find_token(bdsb_id, buf, id_width[1]) && gnss->bds != NULL)
+		if ( pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(gnss->bds->iono_b,  buf+id_width[1]+1, len-id_width[1], field_count[1]) )
+			gnss->bds->iono_valid = 1;
+		else
+			return 0;
+
+	return 1;
+}
+
+		// ephemeris file header ionospheric correction - single line
+char pony_gnss_io_rinex_eph_file_header_parse_iono_corr_line(double *iono,  char *buf, const size_t len, const size_t field_count) {
+
+	const size_t field_width = 12;
+
+	size_t i, j, n;
+	int scanned;
+	char c;
+
+	for (n = 0; n < len && buf[n]; n++);
+	for (i = 0, j = 0; i < field_count && buf[j] && j < n; i++) {
+		if (j > n-field_width)
+			break;
+		c = buf[j+field_width];
+		buf[j+field_width] = '\0';
+
+		pony_gnss_io_rinex_charrep(buf+j, 'D', 'E'); pony_gnss_io_rinex_charrep(buf+j, 'd', 'e');
+		scanned = sscanf( buf+j, "%lg", &(iono[i]) );
+		if (scanned < 1)
+			break;
+
+		j += field_width;
+		buf[j] = c;
+	}
+
+	return (i == field_count) ? 1 : 0;
+}
+
+		// ephemeris file header time system correction
+char pony_gnss_io_rinex_eph_file_header_parse_time_corr(pony_gnss *gnss,  char *buf, const size_t len) {
+
+	const char gps_time_id[] = "GP", glo_time_id[] = "GL", gal_time_id[] = "GA", bds_time_id[] = "BD";
+	const size_t time_id_len = 2;
+
+	size_t i, i1, n;
+
+	for (n = 0; n < len && buf[n]; n++);
+	i = 0;
+	for (; buf[i] <= ' ' && i < n-time_id_len; i++); // skip non-printables
+	if (i >= n)
+		return 0;
+	i1 = i + time_id_len;
+	if (pony_gnss_io_rinex_find_token(gps_time_id, buf+i, n-i) && gnss->gps != NULL) // apply to gps
+		pony_gnss_io_rinex_eph_file_header_parse_time_corr_line(gnss->gps->clock_corr, gnss->gps->clock_corr_to, &(gnss->gps->clock_corr_valid),  buf+i1, n-i1);
+	if (pony_gnss_io_rinex_find_token(glo_time_id, buf+i, n-i) && gnss->glo != NULL) // apply to glonass
+		pony_gnss_io_rinex_eph_file_header_parse_time_corr_line(gnss->glo->clock_corr, gnss->glo->clock_corr_to, &(gnss->glo->clock_corr_valid),  buf+i1, n-i1);
+	if (pony_gnss_io_rinex_find_token(gal_time_id, buf+i, n-i) && gnss->gal != NULL) // apply to galileo
+		pony_gnss_io_rinex_eph_file_header_parse_time_corr_line(gnss->gal->clock_corr, gnss->gal->clock_corr_to, &(gnss->gal->clock_corr_valid),  buf+i1, n-i1);
+	if (pony_gnss_io_rinex_find_token(bds_time_id, buf+i, n-i) && gnss->bds != NULL) // apply to beidou
+		pony_gnss_io_rinex_eph_file_header_parse_time_corr_line(gnss->bds->clock_corr, gnss->bds->clock_corr_to, &(gnss->bds->clock_corr_valid),  buf+i1, n-i1);
+
+	return 1;
+}
+
+		// ephemeris file header time system correction - single line
+void pony_gnss_io_rinex_eph_file_header_parse_time_corr_line(double *clock_corr, char *time_sys, char *valid,  char *buf, const size_t len) {
+
+	const size_t time_id_len = 2, clock_corr_terms_count = 4, clock_corr_terms_len[] = {17, 16, 7, 5};
+
+	size_t i, j, n;
+	int scanned;
+	char c;
+
+	for (n = 0; n < len && buf[n]; n++);
+	for (i = 0, j = 0; j < time_id_len && buf[i] && i < n; j++, i++)
+		time_sys[j] = buf[i];
+	if (i >= n-1)
+		return;
+
+	i++; // skip one position
+
+	for (j = 0; j < clock_corr_terms_count && buf[i]; j++) {
+		if (i > n-clock_corr_terms_len[j])
+			break;
+		c = buf[i+clock_corr_terms_len[j]];
+		buf[i+clock_corr_terms_len[j]] = '\0';
+
+		pony_gnss_io_rinex_charrep(buf+i, 'D', 'E'); pony_gnss_io_rinex_charrep(buf+i, 'd', 'e');
+		scanned = sscanf(buf+i, "%lg", &(clock_corr[j]));
+		if (scanned && j == 1)
+			*valid = 1;
+
+		i += clock_corr_terms_len[j];
+		buf[i] = c;
+	}
+}
+
+	// file header leap seconds
+char pony_gnss_io_rinex_file_header_parse_leap_sec(pony_gnss *gnss,  char *buf, const size_t len) {
+
+	const size_t field_width = 6; // only the first value is being parsed
+
+	size_t n;
+	int scanned;
+	char c;
+
+	for (n = 0; n < len && buf[n]; n++);
+	if (field_width > n)
+		return 0;
+
+	c = buf[field_width];
+	buf[field_width] = '\0';
+
+	scanned = sscanf( buf, "%d", &(gnss->leap_sec) );
+	if (scanned == 1 && gnss->leap_sec > 0)
+		gnss->leap_sec_valid = 1;
+	else
+		return 0;
+
+	buf[field_width] = c;
+
+	return 1;
+}
+
+	// ephemeris file records
+void pony_gnss_io_rinex_eph_file_records_read(
+	pony_gnss_sat *sat, pony_time_epoch *gnss_epoch, 
+	FILE *fp, char *buf, double *eph, unsigned int *sn, 
+	const size_t sys, const size_t maxsat, const size_t maxeph) 
+{
+
+	enum sys_index {gps, glo, gal, bds, sys_count};
+	const char sys_id[sys_count+1] = "GREC"; // GNSS system identifiers: GPS, GLONASS, Galileo, BeiDou, see RINEX documentation
+	const size_t														// gps glo gal bds
+				sys_record_lines							[sys_count] = { 7,  3,  7,  7}, 
+				sys_total_eph								[sys_count] = {35, 21, 34, 35};
+	const int	sys_update_older_ephemeris_if_less_than_min	[sys_count] = {61, 16,  6, 31};
+	const size_t sat_id_width = 3, header_eph_count = 9;
+
+	size_t i;
+	int scanned = 0;
+	char refepoch_flag;	// 1 if reference epoch exists, 0 otherwise 
+	pony_time_epoch epoch, satepoch;
+
+	// safety check
+	if (sat == NULL || gnss_epoch == NULL || fp == NULL || buf == NULL || eph == NULL || sn == NULL)
+		return;
+	
+	while ( !feof(fp) ) { // read until end of file occurs
+
+		// check if eph buffers contain correct ephemeris, to use them for updating satellite data
+		refepoch_flag = pony_gnss_io_rinex_epoch_check(gnss_epoch);
+		if ( pony_gnss_io_rinex_epoch_from_array(&epoch, eph) )
+			if ( *sn > 0 && *sn <= maxsat && ( 
+				   !pony_gnss_io_rinex_epoch_from_array(&satepoch, sat[*sn-1].eph) 
+				|| (refepoch_flag && pony_time_epochs_compare(&satepoch, gnss_epoch) < 0)
+
+				// temporary measure(?) if there are e.g. two sets for the same GPS sat with less than 1 hour between them, say 11:59:44 and 12:00:00
+				|| (abs( (satepoch.h*60+satepoch.m)-(epoch.h*60+epoch.m) ) <  sys_update_older_ephemeris_if_less_than_min[sys]                          )
+				|| (abs( (satepoch.h*60+satepoch.m)-(epoch.h*60+epoch.m) ) > -sys_update_older_ephemeris_if_less_than_min[sys]+pony->gnss_const.sec_in_d)
+
+				) ) {
+				for (i = 0; i < maxeph; i++)
+					sat[*sn-1].eph[i] = eph[i];
+				sat[*sn-1].eph_valid = 1;
+			}
+			else if (refepoch_flag && pony_time_epochs_compare(&satepoch, gnss_epoch) >= 0 && pony_time_epochs_compare(&satepoch, &epoch) < 0)
+				break;
+
+		// wait for system identifier 
+		for (buf[0] = '\0'; buf != NULL && buf[0] != sys_id[sys]; )
+			buf = fgets(buf,PONY_GNSS_IO_RINEX_BUFFER_SIZE-1,fp);
+		if (buf == NULL)
+			break;
+		
+		// try to parse the sn next to the system identifier
+		scanned = sscanf(buf,"%*c%2u", sn);
+		if (scanned < 1 || *sn == 0 || *sn > maxsat)
+			continue; // something is wrong
+
+		for (i = 0; i < maxeph; i++) // reset ephemeris in the buffer
+			eph[i] = 0.0;
+		
+		if ( !pony_gnss_io_rinex_eph_file_parse_record_header(eph, buf+sat_id_width, PONY_GNSS_IO_RINEX_BUFFER_SIZE-sat_id_width-1) // try to parse the first line
+			 || !pony_gnss_io_rinex_epoch_from_array(&epoch, eph) 
+			 || pony_gnss_io_rinex_eph_file_parse_record_lines(eph+header_eph_count,  fp, buf, sys_record_lines[sys]) < sys_total_eph[sys] // parse the rest of the lines (system-dependent, see RINEX documentation)
+			 )
+			continue;
+	}
+
+}
+
+		// ephemeris file record header
+char pony_gnss_io_rinex_eph_file_parse_record_header(double *eph, char *buf, const size_t len) {
+
+	const size_t field_count = 9;
+	const size_t field_width[] = {5, 3, 3, 3, 3, 3,  19, 19, 19};
+
+	size_t i, k, n;
+	int scanned;
+	char c;
+
+	for (n = 0; n < len && buf[n]; n++);
+	pony_gnss_io_rinex_charrep(buf, 'D', 'E'); pony_gnss_io_rinex_charrep(buf, 'd', 'e');
+	for (i = 0, k = 0; i < field_count; i++) {
+		if (k >= n-field_width[i] || buf[k] == '\0')
+			break;
+		c = buf[k+field_width[i]];
+		buf[k+field_width[i]] = '\0';
+
+		scanned = sscanf( buf+k, "%lg", &(eph[i]) );
+		if (scanned < 1)
+			break;
+
+		k += field_width[i];
+		buf[k] = c;
+	}
+
+	return (i == field_count)? 1 : 0;
+}
+
+		// ephemeris file single record
+size_t pony_gnss_io_rinex_eph_file_parse_record_lines(double *eph,  FILE *fp, char *buf, const size_t lines) {
+
+	const size_t rec_per_line = 4, rec_width = 19, blank_width = 4;
+
+	size_t i, k, line, n, total;
+	int scanned;
+	char c;
+
+	for (line = 1, total = 0; line <= lines; line++) {
+		fgets(buf,PONY_GNSS_IO_RINEX_BUFFER_SIZE-1,fp);
+		for (n = 0; buf[n] != '\0'; n++); // determine total length
+		pony_gnss_io_rinex_charrep(buf, 'D', 'E'); pony_gnss_io_rinex_charrep(buf, 'd', 'e');
+		for (i = 0, k = blank_width; i < rec_per_line; i++) {
+			if (k >= n-rec_width || buf[k] == '\0')
+				break;
+			c = buf[k+rec_width];
+			buf[k+rec_width] = '\0';
+
+			scanned = sscanf( buf+k, "%lg", &(eph[total]) );
+			if (scanned < 1)
+				break;
+
+			total++;
+			k += rec_width;
+			buf[k] = c;
+		}
+		if (line < lines && i < rec_per_line)
+			break;
+	}
+	return total;
+
+}
+
+
+
+
+
+
+// service routines
+void pony_gnss_io_rinex_drop_flags_pony_sats(pony_gnss_sat *sat, const size_t sat_count, const size_t obs_count) {
+
+	size_t i, s;
+
+	for (s = 0; s < sat_count; s++) {
+		sat[s].t_em_valid = 0;
+		sat[s].x_valid = 0;
+		sat[s].v_valid = 0;
+		for (i = 0; i < obs_count; i++)
+			sat[s].obs_valid[i] = 0;
+	}
+
+}
+
+void pony_gnss_io_rinex_drop_flags_pony_sol(pony_sol *sol) {
+
+	sol->  x_valid = 0;
+	sol->llh_valid = 0;
+	sol->  v_valid = 0;
+	sol->  q_valid = 0;
+	sol->  L_valid = 0;
+	sol->rpy_valid = 0;
+	sol-> dt_valid = 0;
+
+}
+
+
+
+
+		// free memory with NULL-check and NULL-assignment
+void pony_gnss_io_rinex_free_null(void **ptr) {
+
+	if (*ptr == NULL)
+		return;
+	
+	free(*ptr);
+	*ptr = NULL;
+
+}
+
+
+
+
+
+void pony_gnss_io_rinex_charrep(char *s, char oldc, char newc) {
+	size_t i;
+
+	for (i = 0; s[i]; i++)
+		if (s[i] == oldc)
+			s[i] = newc;
+}
+
+char pony_gnss_io_rinex_read_token_str(char *value,  const char *token, const char *src, const size_t len) {
+
+	const char delim = '=', quote = '"', brace_open = '{', brace_close = '}';
+
+	size_t i, j, k, n, len1;
+	
+	value[0] = 0;
+
+	for (n = 0; token[n]; n++); // determine token length
+	if (n == 0)
+		return 0;
+	len1 = len - n;
+
+	// look for the token
+	for (i = 0, j = 0, k = 0; i < len1 && src[i]; i++) // throughout the string
+		if (src[i] == quote) // skip quoted values
+			for (i++; src[i] && i < len1 && src[i] != quote; i++);
+		else if (src[i] == brace_open) // skip groups
+			for (i++; src[i] && i < len1 && src[i] != brace_close; i++);
+		else {
+			for (j = 0, k = i; j < n && src[k] == token[j]; j++, k++); // check token
+			if (j == n) // token found
+				break;
+		}
+	if (j < n) // token not found
+		return 0;
+
+	// try to parse
+	for (i = k+1; i < len && src[i] && src[i] <= ' '; i++); // skip all non-printables
+	if (i >= len || src[i] != delim) // no delimiter found
+		return 0; 
+
+	for (i++; i < len && src[i] && src[i] <= ' '; i++); // skip the delimiter and all non-printables
+	if (i >= len || src[i] != quote) // no opening quote found
+		return 0;
+
+	for (i++, j = 0; i < len && src[i] && src[i] != quote; i++, j++) // copy until the closing quote appears
+		value[j] = src[i];
+	value[j] = 0;
+	if (i >= len) // no closing quote found
+		return 0;
+
+	return 1;
+
+}
+
+char pony_gnss_io_rinex_read_token_double(double *dest, const char *token, const char *src, const size_t len) {
+
+	const char delim = '=', quote = '"', brace_open = '{', brace_close = '}';
+	size_t i, j, n;
+	char token_found = 0;
+
+	for (n = 0; n < len && src[n]; n++);
+	for (i = 0; !token_found && src[i] && i < n; ) {
+		if (src[i] == quote) // skip quoted values
+			for (i++; src[i] && i < n && src[i] != quote; i++);
+		else if (src[i] == brace_open) // skip groups
+			for (i++; src[i] && i < n && src[i] != brace_close; i++);
+		else {
+			j = 0;
+			if (src[i] == token[j]) {
+				token_found = 1;
+				for (i++,j++; src[i] && token[j] && i < n; i++,j++)
+					if (src[i] != token[j]) {
+						token_found = 0;
+						break;
+					}
+				if (token[j])
+					token_found = 0;
+			}
+			else
+				i++;
+		}
+	}
+	if (!token_found)
+		return 0;
+
+	for (i++; i < n && src[i] && src[i] <= ' '; i++); // skip all non-printables
+	if (!src[i] || i == n || src[i] != delim)
+		return 0; // no delimiter found
+
+	for (i++; i < n && src[i] && src[i] <= ' '; i++); // skip the delimiter and all non-printables
+	if (!src[i] || i == n)
+		return 0; // no token value found
+
+	if (sscanf(src+i,"%lg",dest) < 1)	// try to scan double value
+		return 0;							// failed to scan
+	else
+		return 1;							// success
+
+}
+
+char pony_gnss_io_rinex_find_token(const char *token, const char *src, const size_t len) {
+
+	size_t i, j = 0, k, n, len1;
+
+	for (n = 0; token[n]; n++); // determine token length
+
+	for (i = 0, len1 = len-n+1; src[i] && i < len1; i++) {
+		for (j = 0, k = i; j < n && src[k] == token[j]; j++, k++);
+		if (j == n) // all characters matched
+			return 1;
+	}
+
+	return 0;
+
+}
+
+char pony_gnss_io_rinex_epoch_from_array(pony_time_epoch *epoch, double *YMDhms) {
+
+	epoch->Y = pony_gnss_io_rinex_resolve_2digit_year( (int)(YMDhms[0]) );
+	epoch->M = (int)(YMDhms[1]);
+	epoch->D = (int)(YMDhms[2]);
+	epoch->h = (int)(YMDhms[3]);
+	epoch->m = (int)(YMDhms[4]);
+	epoch->s = YMDhms[5];
+
+	return pony_gnss_io_rinex_epoch_check(epoch);
+}
+
+char pony_gnss_io_rinex_epoch_check(pony_time_epoch *epoch) {
+	const double time_precision = 1./(0x01<<5); // 1/32 sec, half precision step between 32 and 64
+	return (
+		   epoch->Y <  0					|| (100 <= epoch->Y && epoch->Y < 1980)
+		|| epoch->M <= 0					|| epoch->M > 12
+		|| epoch->D <= 0					|| epoch->D > 31
+		|| epoch->h <  0					|| epoch->h > 23
+		|| epoch->m <  0					|| epoch->m > 59
+		|| epoch->s <  0.0-time_precision	|| epoch->s > 60.0+time_precision)? 0 : 1;
+}
+
+int  pony_gnss_io_rinex_resolve_2digit_year(int Y) {
+	if (Y >= 100 || Y < 0)
+		return Y;
+
+	if (Y >= 80)
+		return Y + 1900;
+	else
+		return Y + 2000;
+}
+
+double pony_gnss_io_rinex_dmod(double x, double y) {
+
+    return x - (int)(x/y) * y;
+}

--- a/gnss/io/pony_gnss_io_rinex.h
+++ b/gnss/io/pony_gnss_io_rinex.h
@@ -1,0 +1,8 @@
+// Aug-2020
+//
+/*	pony_gnss_io_rinex 
+	
+	pony plugins for GNSS RINEX input/output:
+*/
+void pony_gnss_io_rinex_v3_read_obs_from_file(void); // reads observation data (measurements) from RINEX v3.0x files
+void pony_gnss_io_rinex_read_eph_from_file   (void); // reads navigation data  (ephemeris)    from RINEX v2-3  files

--- a/gnss/io/pony_gnss_io_ublox.c
+++ b/gnss/io/pony_gnss_io_ublox.c
@@ -1,0 +1,1787 @@
+// Aug-2020
+//
+/*	pony_gnss_io_ublox 
+	
+	pony plugins for GNSS u-Blox receiver input/output:
+
+	- pony_gnss_io_ublox_read_file 
+		Reads raw observation and navigation data (measurements and ephemeris) from u-Blox binary files.
+		Processes messages RXM-RAW/RXM-EPH (GPS L1-only) and RXM-RAWX/RXM-SFRBX
+		Tested for UBX protocol versions 6, M8T, F9T/F9P.
+		Supports GPS, GLONASS, Galileo and BeiDou systems.
+		Multi-receiver/multi-antenna capable, with syncronization option.
+	
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#include "../../pony.h"
+
+// pony bus version check
+#define PONY_GNSS_IO_UBLOX_BUS_VERSION_REQUIRED 8
+#if PONY_BUS_VERSION < PONY_GNSS_IO_UBLOX_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+// UBX signal ID conversion table
+#define PONY_GNSS_IO_UBLOX_MAX_SIGNAL_TYPES_PER_SYS 4
+typedef struct // gnss signal id conversion table entry
+{
+	unsigned char gnss_id;
+	size_t        types;
+	unsigned char ubx_sig_id[PONY_GNSS_IO_UBLOX_MAX_SIGNAL_TYPES_PER_SYS];
+	char          rnx_sig_id[PONY_GNSS_IO_UBLOX_MAX_SIGNAL_TYPES_PER_SYS][2];
+} pony_gnss_io_ublox_signal_id_converson_table_struct;
+
+const pony_gnss_io_ublox_signal_id_converson_table_struct pony_gnss_io_ublox_signal_id_conversion_table[] = {
+	{   // gps
+		0,
+		3, 
+		{  0,        3,        4      },
+		{{'1','C'},{'2','L'},{'2','M'}}
+	},{ // glo
+		6,
+		2, 
+		{  0,        2},
+		{{'1','C'},{'2','C'}}
+	},{ // gal
+		2,
+		4, 
+		{  0,        1,        5,        6      },
+		{{'1','C'},{'1','B'},{'7','I'},{'7','Q'}}
+	},{ // bds
+		3,
+		4, 
+		{  0,        1,        2,        3      },
+		{{'1','I'},{'2','I'},{'7','I'},{'7','D'}}
+	}
+};
+
+// message data structures
+	// RXM-RAWX: multi-gnss raw measurement data, as in u-blox ZED-F9P Interface Description UBX-18010854-R07 p. 182 / u-blox ZED-F9T Interface Description UBX-18053584-R02 p. 174
+typedef struct {
+	double			rcvTow;
+	unsigned short	week;
+	  signed char	leapS;
+	unsigned char	numMeas;
+	unsigned char	recStat;
+	unsigned char	version;
+	unsigned char	reserved1[2];
+} pony_gnss_io_ublox_RXM_RAWX_header;
+typedef struct {
+	         double	prMes;
+	         double	cpMes;
+	         float	doMes;
+	unsigned char	gnssId;
+	unsigned char	  svId;
+	unsigned char	 sigId;
+	unsigned char	freqId;
+	unsigned short	locktime;
+	unsigned char	cno;
+	unsigned char	prStdev;
+	unsigned char	cpStdev;
+	unsigned char	doStdev;
+	unsigned char	trkStat;
+	unsigned char	reserved2;
+} pony_gnss_io_ublox_RXM_RAWX_block;
+	// RXM-RAW: GPS L1 raw measurement data, as in u-blox 6 Receiver Description GPS.G6-SW-10018-F p. 185
+typedef struct {
+	  signed long  int  iTOW;
+	  signed short int  week;
+	unsigned       char numSV;
+	unsigned       char reserved1;
+} pony_gnss_io_ublox_RXM_RAW_header;
+typedef struct {
+	         double cpMes;
+	         double prMes;
+	         float  doMes;
+	unsigned char   sv;
+	  signed char   mesQI;
+	  signed char   cno;
+	unsigned char   lli;
+} pony_gnss_io_ublox_RXM_RAW_block;
+	// RXM-SFRBX: multi-GNSS broadcast navigation data subframe, as in u-blox ZED-F9P Interface Description UBX-18010854-R07 p. 187 / u-blox ZED-F9T Interface Description UBX-18053584-R02 p. 182
+typedef struct {
+	unsigned char	gnssId;
+	unsigned char	  svId;
+	unsigned char	reserved1;
+	unsigned char	freqId;
+	unsigned char	numWords;
+	unsigned char	chn;
+	unsigned char	version;
+	unsigned char	reserved2;
+} pony_gnss_io_ublox_RXM_SFRBX_header;
+typedef struct {
+	unsigned long   dwrd[10];
+} pony_gnss_io_ublox_RXM_SFRBX_block;
+	// RXM-EPH: GPS aiding ephemeris output message, as in u-blox 6 Receiver Description GPS.G6-SW-10018-F p. 184
+typedef struct {
+	unsigned long	svid;
+	unsigned long	how;
+} pony_gnss_io_ublox_RXM_EPH_header;
+typedef struct {
+	unsigned long	sf[3][8];
+} pony_gnss_io_ublox_RXM_EPH_block;
+	
+
+// navigation subframe parsing
+typedef struct {
+	size_t			wrd;	// word number (starting with 0)
+	unsigned char	shift;	// bit shift within the word
+	unsigned char	bits;	// bit count
+	size_t			msb;	// index of most significant bits entry (scale and eph ignored there), or UINT_MAX if there are none
+	double			scale;	// scale factor (LSB), negative for signed numbers
+	size_t			eph;	// ephemeris array index (according to RINEX, starting with 0 for epoch year)
+} pony_gnss_io_ublox_nav_subframe_conversion_entry;
+char pony_gnss_io_ublox_nav_subframe_parse_data(double *eph, unsigned long *dwrd, pony_gnss_io_ublox_nav_subframe_conversion_entry *conversion_table, const size_t entries_count, const char complement);
+char pony_gnss_io_ublox_nav_subframe_parser_gps(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe);
+char pony_gnss_io_ublox_nav_subframe_parser_glo(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe);
+char pony_gnss_io_ublox_nav_subframe_parser_gal(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe);
+char pony_gnss_io_ublox_nav_subframe_parser_bds(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe);
+
+// message parsers
+size_t pony_gnss_io_ublox_file_read_message(pony_gnss *gnss, FILE *fp, void *hdr_buf, void *blk_buf); // read message from stream
+char   pony_gnss_io_ublox_file_parse_RXM_RAWX (unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr, void *blk); // RXM-RAWX : multi-gnss raw measurement data
+char   pony_gnss_io_ublox_file_parse_RXM_RAW  (unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr, void *blk); // RXM-RAW  : GPS L1 raw measurement data
+char   pony_gnss_io_ublox_file_parse_RXM_SFRBX(unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr, void *blk); // RXM-SFRBX: multi-GNSS broadcast navigation data subframe
+char   pony_gnss_io_ublox_file_parse_RXM_EPH  (unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr, void *blk); // RXM-EPH  : GPS aiding ephemeris output message
+
+// internal routines
+void   pony_gnss_io_ublox_glonass_day2date(pony_time_epoch *epoch, unsigned int day);								// GLONASS day into 4-year cycle to date closest to given year
+void   pony_gnss_io_ublox_checksum_recurse(unsigned char *cs,  unsigned char byte);									// UBX recursive checksum
+char   pony_gnss_io_ublox_obs_types_allocate(char (**obs_types)[4], size_t *obs_count, pony_gnss_sat *sat, const size_t sat_count, const pony_gnss_io_ublox_signal_id_converson_table_struct *sig); // observation types handling
+void   pony_gnss_io_ublox_drop_flags_pony_sats(pony_gnss_sat *sat, const size_t sat_count, const size_t obs_count);	// drop satellite flags
+void   pony_gnss_io_ublox_drop_flags_pony_sol(pony_sol *sol);														// drop solution flags
+void   pony_gnss_io_ublox_free_null(void **ptr);																	// memory release with NULL-check and NULL-asignment 
+int    pony_gnss_io_ublox_round(double x);																			// round to the nearest integer
+double pony_gnss_io_ublox_dmod(double x, double y);																	// remainder after division for doubles
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// plugin definitions
+
+/* pony_gnss_io_ublox_read_file - pony plugin
+	
+	Reads raw observation and navigation data (measurements and ephemeris) from u-Blox binary files.
+	Processes messages RXM-RAW/RXM-EPH (GPS L1-only) and RXM-RAWX/RXM-SFRBX
+	Tested for UBX protocol versions 6, M8T, F9T/F9P.
+	Supports GPS, GLONASS, Galileo and BeiDou systems.
+	Multi-receiver/multi-antenna capable, with syncronization option.
+	When new issue of navigation data starts, this plugin drops ephemeris validity flag, 
+	so satellite stops being used (except for continuous integration in GLONASS).
+
+	uses:
+		pony->gnss_count
+		pony->gnss[].gps/glo/gal/bds->max_sat_count
+		pony->gnss[].gps/glo/gal/bds->max_eph_count
+	changes:
+		pony->mode
+		pony->gnss[].epoch
+		pony->gnss[].leap_sec
+		pony->gnss[].leap_sec_valid
+		pony->gnss[].gps/glo/gal/bds->obs_count
+		pony->gnss[].gps/glo/gal/bds->obs_types
+		pony->gnss[].gps/glo/gal/bds->sat[]. eph
+		pony->gnss[].gps/glo/gal/bds->sat[]. eph_valid
+		pony->gnss[].gps/glo/gal/bds->sat[]. obs
+		pony->gnss[].gps/glo/gal/bds->sat[]. obs_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].t_em_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].   x_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].   v_valid
+		pony->gnss[].glo->freq_slot
+		pony->gnss[].sol.  x_valid
+		pony->gnss[].sol.llh_valid
+		pony->gnss[].sol.  v_valid
+		pony->gnss[].sol.  q_valid
+		pony->gnss[].sol.  L_valid
+		pony->gnss[].sol.rpy_valid
+		pony->gnss[].sol. dt_valid
+	cfg parameters:
+		{gnss: ubx_in} - gnss u-blox data input source
+			type   : string
+			range  : valid file name
+			default: none
+			example: {gnss: ubx_in = "data/2019_10/191025_0255/base_1025.bin"}
+		gnss_sync - multi-receiver observations synchronization threshold, sec
+			type   : floating point
+			range  : >0
+			default: none
+			example: gnss_sync = 0.09
+			negative values result in sync turned off
+*/
+void pony_gnss_io_ublox_read_file(void) {
+
+	enum  system_id {gps, glo, gal,	bds, sys_count}; // supported constellations
+	// supported messages
+	enum ubx_msg_id									  { RXM_RAWX,							RXM_SFRBX,								RXM_RAW,							RXM_EPH, msg_id_count};
+
+	const char cfg_file_token[] = "ubx_in", gnss_sync_token[] = "gnss_sync", quote = '"';
+	const size_t payload_hdr_size[msg_id_count]		= { sizeof(pony_gnss_io_ublox_RXM_RAWX_header),	sizeof(pony_gnss_io_ublox_RXM_SFRBX_header),	sizeof(pony_gnss_io_ublox_RXM_RAW_header),	sizeof(pony_gnss_io_ublox_RXM_EPH_header)};
+	const size_t payload_blk_size[msg_id_count]		= { sizeof(pony_gnss_io_ublox_RXM_RAWX_block ),	sizeof(pony_gnss_io_ublox_RXM_SFRBX_block ),	sizeof(pony_gnss_io_ublox_RXM_RAW_block ),	sizeof(pony_gnss_io_ublox_RXM_EPH_block )};
+
+	static FILE **fp = NULL;
+	static double gnss_sync = -1;
+	static void *payload_hdr, *payload_blk;
+
+	size_t r, i, id, count;
+	char *str;
+	pony_time_epoch latest_epoch = {0,0,0,0,0,0};
+
+	// init
+	if (pony->mode == 0)	{
+
+		// requires gnss data initialized
+		if (pony->gnss == NULL) {
+			pony->mode = -1;
+			return;
+		}
+
+		// allocate memory
+			// file pointers, memory buffers and observation format specifiers
+		fp          = (FILE **)calloc( pony->gnss_count, sizeof(FILE *) );
+		// memory buffers
+		for (i = 0, count = 0; i < msg_id_count; i++)
+			if (payload_hdr_size[i] > count)
+				count = payload_hdr_size[i];
+		payload_hdr = (void *)malloc(count);
+		for (i = 0, count = 0; i < msg_id_count; i++)
+			if (payload_blk_size[i] > count)
+				count = payload_blk_size[i];
+		payload_blk = (void *)malloc(count);
+		if (
+			   fp			== NULL
+			|| payload_hdr	== NULL
+			|| payload_blk	== NULL	
+			) {
+			printf("\nERROR: memory allocation failed for ublox data");
+			pony->mode = -1;
+			return;
+		}
+
+		for (r = 0; r < pony->gnss_count; r++) {
+			// requires gnss data initialized
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			// ubx file name from configuration
+			str = pony_locate_token(cfg_file_token, pony->gnss[r].cfg_settings, pony->gnss[r].settings_length, '=');
+			if ( str == NULL || str[0] == '\0' ) {
+				printf("\n\terror: could not find GNSS ubx file name in the configuration for gnss[%d]:\n\t\t'%s'",
+					r, pony->gnss[r].cfg_settings);
+				pony->mode = -1;
+				return;
+			}
+			for ( ; str < pony->gnss[r].cfg_settings+pony->gnss[r].settings_length && *str && *str <= ' '; str++);
+			if (*str != quote || str >= pony->gnss[r].cfg_settings + pony->gnss[r].settings_length || !(*str)) {
+				printf("\n\terror: could not parse GNSS ubx file name in the configuration for gnss[%d]:\n\t\t'%s'",
+					r, pony->gnss[r].cfg_settings);
+				pony->mode = -1;
+				return;
+			}
+			for (str++, i = 0; str+i < pony->gnss[r].cfg_settings+pony->gnss[r].settings_length && str[i] && str[i] != quote; i++);
+			if (str+i >= pony->gnss[r].cfg_settings + pony->gnss[r].settings_length || !(str[i])) {
+				printf("\n\terror: could not parse GNSS ubx file name in the configuration for gnss[%d]:\n\t\t'%s'",
+					r, pony->gnss[r].cfg_settings);
+				pony->mode = -1;
+				return;
+			}
+			// open the file
+			str[i] = '\0';
+			fp[r] = fopen(str,"rb");
+			if (fp[r] == NULL) {
+				printf("\n\terror: could not open GNSS ubx file '%s' for gnss[%d]",str,r);
+				str[i] = quote;
+				pony->mode = -1;
+				return;
+			}
+			printf("\n\tubx binary file '%s' opened",str);
+			str[i] = quote;
+			// observation types
+			if (   ( pony->gnss[r].gps !=NULL && !pony_gnss_io_ublox_obs_types_allocate(&(pony->gnss[r].gps->obs_types), &(pony->gnss[r].gps->obs_count), pony->gnss[r].gps->sat, pony->gnss[r].gps->max_sat_count, &(pony_gnss_io_ublox_signal_id_conversion_table[gps])) )
+				|| ( pony->gnss[r].glo !=NULL && !pony_gnss_io_ublox_obs_types_allocate(&(pony->gnss[r].glo->obs_types), &(pony->gnss[r].glo->obs_count), pony->gnss[r].glo->sat, pony->gnss[r].glo->max_sat_count, &(pony_gnss_io_ublox_signal_id_conversion_table[glo])) )
+				|| ( pony->gnss[r].gal !=NULL && !pony_gnss_io_ublox_obs_types_allocate(&(pony->gnss[r].gal->obs_types), &(pony->gnss[r].gal->obs_count), pony->gnss[r].gal->sat, pony->gnss[r].gal->max_sat_count, &(pony_gnss_io_ublox_signal_id_conversion_table[gal])) )
+				|| ( pony->gnss[r].bds !=NULL && !pony_gnss_io_ublox_obs_types_allocate(&(pony->gnss[r].bds->obs_types), &(pony->gnss[r].bds->obs_count), pony->gnss[r].bds->sat, pony->gnss[r].bds->max_sat_count, &(pony_gnss_io_ublox_signal_id_conversion_table[bds])) )
+				) {
+				printf("\n\terror: could not allocate memory for observation types in gnss[%d]",r);
+				pony->mode = -1;
+				return;
+			}
+		}
+
+		// check for gnss_sync option
+		str = pony_locate_token(gnss_sync_token, pony->cfg_settings, pony->settings_length, '=');
+		if ( str != NULL && sscanf(str,"%lf",&gnss_sync) && gnss_sync > 0) 
+			printf("\n\n\t GNSS observations will be synchronized by time of day within %.3f msec to the latest one\n", gnss_sync*1e3);
+		else
+			gnss_sync = -1;
+
+		// no return, try to read the first chunk from UBX stream
+	}
+
+	// terminate
+	if (pony->mode < 0)	{
+
+		// close files, if not already
+		if (fp != NULL) {
+			for (r = 0; r < pony->gnss_count; r++)
+				if (pony->gnss[r].cfg == NULL)
+					continue;
+				else if (fp[r] != NULL)
+					fclose(fp[r]);
+			free(fp);
+			fp = NULL;
+		}
+		// memory release
+		pony_gnss_io_ublox_free_null(&(payload_hdr));
+		pony_gnss_io_ublox_free_null(&(payload_blk));
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+
+		for (r = 0, count = 0; r < pony->gnss_count; r++) {
+			if (fp[r] == NULL)
+				continue;
+			for (id = UINT_MAX; !feof(fp[r]) && !ferror(fp[r]) && id != RXM_RAWX && id != RXM_RAW; id = pony_gnss_io_ublox_file_read_message(&(pony->gnss[r]), fp[r], payload_hdr, payload_blk) );
+			count += (id == RXM_RAWX || id == RXM_RAW) ? 1 : 0;
+		}
+		
+		if (!count) // no single measurement parsed
+			pony->mode = -1;
+		
+		if (gnss_sync <= 0) // no observation time skew check
+			return;
+		
+		// try to synchronize observations
+			// look for the latest epoch in observations
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			else if (pony_time_epochs_compare(&latest_epoch, &(pony->gnss[r].epoch)) == -1)
+				latest_epoch = pony->gnss[r].epoch;
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			else
+				while ( pony_gnss_io_ublox_dmod((latest_epoch.h*3600+latest_epoch.m*60+latest_epoch.s) - (pony->gnss[r].epoch.h*3600+pony->gnss[r].epoch.m*60+pony->gnss[r].epoch.s), 3600*24) > gnss_sync ) {
+					for (id = UINT_MAX; !feof(fp[r]) && !ferror(fp[r]) && id != RXM_RAWX && id != RXM_RAW; id = pony_gnss_io_ublox_file_read_message(&(pony->gnss[r]), fp[r], payload_hdr, payload_blk) );
+					if (id != RXM_RAWX && id != RXM_RAW) { // end-of-file or file error before syncronized epoch found
+						pony->mode = -1;
+						return;
+					}
+				}
+		
+	}
+
+}
+
+
+
+
+
+
+
+
+
+
+// message parsers
+	// read message from stream
+size_t pony_gnss_io_ublox_file_read_message(pony_gnss *gnss, FILE *fp, void *hdr_buf, void *blk_buf) {
+
+	enum ubx_msg_id									  { RXM_RAWX,							 RXM_SFRBX,							RXM_RAW,							RXM_EPH, msg_id_count};
+
+	const unsigned char	msg_id[msg_id_count][2]	=	{{0x02,0x15},							{0x02,0x13},						{0x02,0x10},						{0x02,0x31}	},
+						sync_char[] = {0xB5, 0x62};
+
+	static char (*msg_parser[])(unsigned char *, pony_gnss *, FILE *, void *, void *)
+													= {pony_gnss_io_ublox_file_parse_RXM_RAWX,		pony_gnss_io_ublox_file_parse_RXM_SFRBX,	pony_gnss_io_ublox_file_parse_RXM_RAW,		pony_gnss_io_ublox_file_parse_RXM_EPH};
+
+	unsigned char cs[2], buf[2];
+	size_t id;
+	short len;
+
+	if ( feof(fp) || ferror(fp) )
+		return UINT_MAX;
+	// synchronize
+	while( fread((void *)(buf),1,1,fp) && ((0xff & *buf) != (0xff & sync_char[0]))  );
+	if ( !(fread((void *)(buf),1,1,fp) && ((0xff & *buf) == (0xff & sync_char[1]))) )
+		return UINT_MAX;
+	// try to parse frame header
+	cs[0] = 0, cs[1] = 0;
+	if (   !fread((void *)(buf+0),1,1,fp)
+		|| !fread((void *)(buf+1),1,1,fp) ) // message class and id expected
+		return UINT_MAX;
+	for (id = 0; id < msg_id_count; id++) // check through message list
+		if (   (0xff & buf[0]) == msg_id[id][0] 
+			&& (0xff & buf[1]) == msg_id[id][1] ) {
+			// renew checksum
+			pony_gnss_io_ublox_checksum_recurse(cs, buf[0]);
+			pony_gnss_io_ublox_checksum_recurse(cs, buf[1]);
+			// message length expected
+			if ( !fread((void *)(&len),2,1,fp) )
+				return UINT_MAX;
+			// renew checksum
+			pony_gnss_io_ublox_checksum_recurse(cs, 0xff & (len>>0));
+			pony_gnss_io_ublox_checksum_recurse(cs, 0xff & (len>>8));
+			// try to parse the message & validate checksum
+			if (   !(msg_parser[id])(cs, gnss, fp, hdr_buf, blk_buf)
+				|| !fread((void *)(buf+0),1,1,fp)   // CK_A checksum expected
+				|| !fread((void *)(buf+1),1,1,fp) ) // CK_B checksum expected
+				return UINT_MAX;
+			if (   (0xff & buf[0]) != cs[0]
+				|| (0xff & buf[1]) != cs[1]) {
+					printf("\n warning: uBlox checksum failed at %lu (epoch %02d/%02d/%02d_%02d:%02d:%06.3f)", ftell(fp),
+						gnss->epoch.Y, gnss->epoch.M, gnss->epoch.D, gnss->epoch.h, gnss->epoch.m, gnss->epoch.s);
+					return UINT_MAX;
+			}
+			return id;
+		}
+	//if (id >= msg_id_count)
+	//	printf("\n warning: unknown ubx message 0x%02x 0x%02x", buf[0], buf[1]);
+
+	return UINT_MAX;
+}
+	// RXM-RAWX: multi-gnss raw measurement data
+char pony_gnss_io_ublox_file_parse_RXM_RAWX(unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr_buf, void *blk_buf) {
+
+	enum  system_id {gps, glo, gal,	bds, sys_count};
+
+	const unsigned char message_version_expected = 0x01;
+	const size_t 
+		chars_8byte = (8*8)/CHAR_BIT, 
+		chars_4byte = (4*8)/CHAR_BIT,
+		freq_id_eph = 16;
+
+	pony_gnss_io_ublox_RXM_RAWX_header *hdr	= NULL;
+	pony_gnss_io_ublox_RXM_RAWX_block  *blk	= NULL;
+	pony_gnss_sat *sat				= NULL;
+	unsigned char *ptr				= NULL;
+	size_t i, j, m, sys, s, maxsat;
+
+	if (cs == NULL || gnss == NULL || fp == NULL || hdr_buf == NULL || blk_buf == NULL)
+		return 0;
+
+	hdr = (pony_gnss_io_ublox_RXM_RAWX_header *)hdr_buf;
+	blk = (pony_gnss_io_ublox_RXM_RAWX_block  *)blk_buf;
+
+	// get header data
+	memset(hdr_buf,0,sizeof(*hdr)); // drop to all zeros
+	if ( !fread((void *)(&(hdr->rcvTow      )),8,1,fp) ) return 0; // R8: time of week
+	if ( !fread((void *)(&(hdr->week        )),2,1,fp) ) return 0; // U2: week
+	if ( !fread((void *)(&(hdr->leapS       )),1,1,fp) ) return 0; // I1: leapS
+	if ( !fread((void *)(&(hdr->numMeas     )),1,1,fp) ) return 0; // U1: numMeas
+	if ( !fread((void *)(&(hdr->recStat     )),1,1,fp) ) return 0; // X1: recStat
+	if ( !fread((void *)(&(hdr->version     )),1,1,fp) ) return 0; // U1: version
+	if ( !fread((void *)(&(hdr->reserved1[0])),1,1,fp) ) return 0; // U1: reserved1[0]
+	if ( !fread((void *)(&(hdr->reserved1[1])),1,1,fp) ) return 0; // U1: reserved1[1]
+	// checksum
+	ptr = (unsigned char *)(&(hdr->rcvTow)); // converting double to chars
+	for (i = 0; i < chars_8byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+	for (j = 0; j < 16; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(hdr->week>>j));
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->leapS       );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->numMeas     );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->recStat     );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->version     );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->reserved1[0]);
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->reserved1[1]);
+	// validate
+	if (hdr->version > message_version_expected)	return 0;
+	if (hdr->rcvTow   < 0)							return 0;
+	if (hdr->numMeas == 0)							return 0;
+	// process
+	if ( !pony_time_gps2epoch(&(gnss->epoch), hdr->week, hdr->rcvTow) ) return 0;
+	if (hdr->recStat & 0x01) {
+		gnss->leap_sec			= hdr->leapS;
+		gnss->leap_sec_valid	= 1;
+	}
+	// drop satellite and solution flags
+	if (gnss->gps != NULL) pony_gnss_io_ublox_drop_flags_pony_sats(gnss->gps->sat, gnss->gps->max_sat_count, gnss->gps->obs_count);
+	if (gnss->glo != NULL) pony_gnss_io_ublox_drop_flags_pony_sats(gnss->glo->sat, gnss->glo->max_sat_count, gnss->glo->obs_count);
+	if (gnss->gal != NULL) pony_gnss_io_ublox_drop_flags_pony_sats(gnss->gal->sat, gnss->gal->max_sat_count, gnss->gal->obs_count);
+	if (gnss->bds != NULL) pony_gnss_io_ublox_drop_flags_pony_sats(gnss->bds->sat, gnss->bds->max_sat_count, gnss->bds->obs_count);
+	pony_gnss_io_ublox_drop_flags_pony_sol(&(gnss->sol));
+	// measurement blocks
+	for (m = 0; m < hdr->numMeas; m++) {
+		// get data
+		memset(blk_buf,0,sizeof(*blk)); // drop to all zeros
+		if ( !fread((void *)(&(blk->prMes    )),8,1,fp) ) return 0; // R8: pseudorange measurement, [m]
+		if ( !fread((void *)(&(blk->cpMes    )),8,1,fp) ) return 0; // R8: carrier phase measurement, [cycles]
+		if ( !fread((void *)(&(blk->doMes    )),4,1,fp) ) return 0; // R4: doppler measurement, [Hz] 
+		if ( !fread((void *)(&(blk->gnssId   )),1,1,fp) ) return 0; // U1: gnss identifier
+		if ( !fread((void *)(&(blk->svId     )),1,1,fp) ) return 0; // U1: satellite identifier 
+		if ( !fread((void *)(&(blk->sigId    )),1,1,fp) ) return 0; // U1: signal identifier 
+		if ( !fread((void *)(&(blk->freqId   )),1,1,fp) ) return 0; // U1: GLONASS frequency slot + 7
+		if ( !fread((void *)(&(blk->locktime )),2,1,fp) ) return 0; // U2: carrier phase locktime counter, [ms] 
+		if ( !fread((void *)(&(blk->cno      )),1,1,fp) ) return 0; // U1: carrier-to-noise density ratio (signal strength), [dBHz]
+		if ( !fread((void *)(&(blk->prStdev  )),1,1,fp) ) return 0; // X1: estimated pseudorange standard deviation, [0.01x2^n m]
+		if ( !fread((void *)(&(blk->cpStdev  )),1,1,fp) ) return 0; // X1: estimated carrier phase standard deviation, [0.004 cycles]
+		if ( !fread((void *)(&(blk->doStdev  )),1,1,fp) ) return 0; // X1: estimated doppler standard deviation, [0.002x2^n Hz] 
+		if ( !fread((void *)(&(blk->trkStat  )),1,1,fp) ) return 0; // X1: tracking status 
+		if ( !fread((void *)(&(blk->reserved2)),1,1,fp) ) return 0; // U1: reserved2
+		// checksum
+		ptr = (unsigned char *)(&(blk->prMes)); // converting double to chars
+		for (i = 0; i < chars_8byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+		ptr = (unsigned char *)(&(blk->cpMes)); // converting double to chars
+		for (i = 0; i < chars_8byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+		ptr = (unsigned char *)(&(blk->doMes)); // converting double to chars
+		for (i = 0; i < chars_4byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->gnssId   );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->svId     );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->sigId    );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->freqId   );
+		for (j = 0; j < 16; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(blk->locktime>>j));
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->cno      );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->prStdev  );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->cpStdev  );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->doStdev  );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->trkStat  );
+		pony_gnss_io_ublox_checksum_recurse(cs,blk->reserved2);
+		// process
+		for (sys = 0; sys < sys_count && blk->gnssId != pony_gnss_io_ublox_signal_id_conversion_table[sys].gnss_id; sys++);
+		if (sys >= sys_count) continue; // unknown gnss constellation
+		switch (sys) {
+			case gps: if (gnss->gps == NULL) continue; else sat = gnss->gps->sat; maxsat = gnss->gps->max_sat_count; break;
+			case glo: if (gnss->glo == NULL) continue; else sat = gnss->glo->sat; maxsat = gnss->glo->max_sat_count; break;
+			case gal: if (gnss->gal == NULL) continue; else sat = gnss->gal->sat; maxsat = gnss->gal->max_sat_count; break;
+			case bds: if (gnss->bds == NULL) continue; else sat = gnss->bds->sat; maxsat = gnss->bds->max_sat_count; break;
+			default : sat = NULL; maxsat = 0;
+		}
+		if (sat == NULL) continue; // gnss constellation not initialized
+		s = blk->svId-1;
+		if (s >= maxsat) continue; // satellite id not supported
+		for (j = 0; j < pony_gnss_io_ublox_signal_id_conversion_table[sys].types && blk->sigId != pony_gnss_io_ublox_signal_id_conversion_table[sys].ubx_sig_id[j]; j++);
+		if (j >= pony_gnss_io_ublox_signal_id_conversion_table[sys].types) continue; // unknown signal id
+		if (sys == glo)
+			if (blk->freqId <= 13) // glonass frequency slot goes into ephemeris
+				sat->eph[freq_id_eph] = blk->freqId - 7;
+			else
+				continue; // invalid data
+		sat[s].obs[j*4+0] =         blk->prMes; // code pseudorange
+		sat[s].obs[j*4+1] =         blk->cpMes; // carrier phase
+		sat[s].obs[j*4+2] = (double)blk->doMes; // doppler shift
+		sat[s].obs[j*4+3] = (double)blk->cno;   // carrier/noise
+		sat[s].obs_valid[j*4+0] = (  blk->trkStat & 0x01                                  ) ? 1 : 0; // code pseudorange validity
+		sat[s].obs_valid[j*4+1] = ( (blk->trkStat & 0x02) && (blk->cpStdev & 0x0f) != 0x0f) ? 1 : 0; // carrier phase validity
+		sat[s].obs_valid[j*4+2] = 1; // doppler shift validity
+		sat[s].obs_valid[j*4+3] = 1; // carrier/noise validity
+		//std = 0.010*(0x01<<blk->prStdev);	if (std > gnss->settings.   code_sigma) gnss->settings.   code_sigma = std;
+		//std = 0.004*blk->cpStdev;			if (std > gnss->settings.  phase_sigma) gnss->settings.  phase_sigma = std;
+		//std = 0.002*(0x01<<blk->doStdev);	if (std > gnss->settings.doppler_sigma) gnss->settings.doppler_sigma = std;
+	}
+
+	return hdr->numMeas;
+}
+	// RXM-RAW: GPS L1 raw measurement data
+char pony_gnss_io_ublox_file_parse_RXM_RAW(unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr_buf, void *blk_buf) {
+
+	const size_t 
+		sigId = 0,
+		chars_8byte = (8*8)/CHAR_BIT, 
+		chars_4byte = (4*8)/CHAR_BIT;
+	const unsigned char   lli_max = 0x07;      // maximum loss of lock indicator value
+	const   signed char mesQI_min = 4;         // minimum measurement quality indicator value
+	const double pr_min = +1e7, pr_max = +3e7, // valid pseudorange span
+		         do_min = -1e4, do_max = +1e4; // valid doppler shift span
+
+	pony_gnss_io_ublox_RXM_RAW_header *hdr	= NULL;
+	pony_gnss_io_ublox_RXM_RAW_block  *blk	= NULL;
+	unsigned char *ptr				= NULL, i, j, s, svid;
+
+	if (   gnss           == NULL 
+		|| gnss->gps      == NULL 
+		|| gnss->gps->sat == NULL 
+		|| cs      == NULL 
+		|| fp      == NULL 
+		|| hdr_buf == NULL 
+		|| blk_buf == NULL)
+		return 0;
+
+	hdr = (pony_gnss_io_ublox_RXM_RAW_header *)hdr_buf;
+	blk = (pony_gnss_io_ublox_RXM_RAW_block  *)blk_buf;
+
+	// get header data
+	memset(hdr_buf,0,sizeof(*hdr)); // drop to all zeros
+	if ( !fread((void *)(&(hdr->iTOW     )),4,1,fp) ) return 0; // I4: measurement integer millisecond GPS time of week
+	if ( !fread((void *)(&(hdr->week     )),2,1,fp) ) return 0; // I2: measurement GPS week number
+	if ( !fread((void *)(&(hdr->numSV    )),1,1,fp) ) return 0; // U1: number of satellites following
+	if ( !fread((void *)(&(hdr->reserved1)),1,1,fp) ) return 0; // U1: reserved
+	// checksum
+	for (j = 0; j < 32; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(hdr->iTOW>>j));
+	for (j = 0; j < 16; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(hdr->week>>j));
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->numSV    );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->reserved1);
+	// validate
+	if (   hdr->iTOW  <  0
+		|| hdr->week  <  0
+		|| hdr->numSV == 0)							return 0;
+	// process
+	if ( !pony_time_gps2epoch(&(gnss->epoch), hdr->week, hdr->iTOW/1000.0) ) return 0;
+	// drop satellite and solution flags
+	pony_gnss_io_ublox_drop_flags_pony_sats(gnss->gps->sat, gnss->gps->max_sat_count, gnss->gps->obs_count);
+	pony_gnss_io_ublox_drop_flags_pony_sol(&(gnss->sol));
+	// measurement blocks
+	for (s = 0; s < hdr->numSV; s++) {
+		// get data
+		memset(blk_buf,0,sizeof(*blk)); // drop to all zeros
+		if ( !fread((void *)(&(blk->cpMes)),8,1,fp) ) return 0; // R8: carrier phase measurement, [cycles]
+		if ( !fread((void *)(&(blk->prMes)),8,1,fp) ) return 0; // R8: pseudorange measurement, [m]
+		if ( !fread((void *)(&(blk->doMes)),4,1,fp) ) return 0; // R4: doppler measurement, [Hz] 
+		if ( !fread((void *)(&(blk->sv   )),1,1,fp) ) return 0; // U1: space vehicle number 
+		if ( !fread((void *)(&(blk->mesQI)),1,1,fp) ) return 0; // I1: nav measurements quality indicator
+		if ( !fread((void *)(&(blk->cno  )),1,1,fp) ) return 0; // I1: signal strength carrier-to-noise ratio, [dBHz]
+		if ( !fread((void *)(&(blk->lli  )),1,1,fp) ) return 0; // U1: loss of lock indicator
+		// checksum
+		ptr = (unsigned char *)(&(blk->cpMes)); // converting double to chars
+		for (i = 0; i < chars_8byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+		ptr = (unsigned char *)(&(blk->prMes)); // converting double to chars
+		for (i = 0; i < chars_8byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+		ptr = (unsigned char *)(&(blk->doMes)); // converting double to chars
+		for (i = 0; i < chars_4byte; i++) for (j = 0; j < CHAR_BIT; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,ptr[i]>>j);
+		pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char)(blk->sv   ));
+		pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char)(blk->mesQI));
+		pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char)(blk->cno  ));
+		pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char)(blk->lli  ));
+		// process
+		if (blk->sv == 0 || blk->sv > gnss->gps->max_sat_count) continue; // satellite id not supported
+		if (   blk->mesQI < mesQI_min 
+			|| blk->cno <= 0 
+			|| blk->lli > lli_max
+			|| blk->prMes < pr_min || blk->prMes > pr_max
+			|| blk->doMes < do_min || blk->doMes > do_max) 
+			return s; // corrupted data
+		svid = blk->sv-1;
+		gnss->gps->sat[svid].obs[sigId*4+0] =         blk->prMes; // code pseudorange
+		gnss->gps->sat[svid].obs[sigId*4+1] =         blk->cpMes; // carrier phase
+		gnss->gps->sat[svid].obs[sigId*4+2] = (double)blk->doMes; // doppler shift
+		gnss->gps->sat[svid].obs[sigId*4+3] = (double)blk->cno;   // carrier/noise
+		gnss->gps->sat[svid].obs_valid[sigId*4+0] = ( blk->mesQI >= mesQI_min        ) ? 1 : 0; // code pseudorange validity
+		gnss->gps->sat[svid].obs_valid[sigId*4+1] = ( blk->mesQI >= 6 && !(blk->lli) ) ? 1 : 0; // carrier phase validity
+		gnss->gps->sat[svid].obs_valid[sigId*4+2] = ( blk->mesQI >= mesQI_min        ) ? 1 : 0; // doppler shift validity
+		gnss->gps->sat[svid].obs_valid[sigId*4+3] = 1;                                          // carrier/noise validity
+	}
+
+	return hdr->numSV;
+}
+	// RXM-SFRBX: multi-GNSS broadcast navigation data subframe
+#define PONY_GNSS_IO_UBLOX_TWO_m05    ((double)1./(0x01<< 5)) // 2^-5
+#define PONY_GNSS_IO_UBLOX_TWO_m11    ((double)1./(0x01<<11)) // 2^-11
+#define PONY_GNSS_IO_UBLOX_TWO_m19    ((double)1./(0x01<<19)) // 2^-19
+#define PONY_GNSS_IO_UBLOX_TWO_m29    ((double)1./(0x01<<29)) // 2^-29
+#define PONY_GNSS_IO_UBLOX_TWO_m31    (PONY_GNSS_IO_UBLOX_TWO_m29/(0x01<< 2)) // 2^-31
+#define PONY_GNSS_IO_UBLOX_TWO_m40    (PONY_GNSS_IO_UBLOX_TWO_m29/(0x01<<11)) // 2^-40
+#define PONY_GNSS_IO_UBLOX_TWO_m43    (PONY_GNSS_IO_UBLOX_TWO_m29/(0x01<<14)) // 2^-43
+#define PONY_GNSS_IO_UBLOX_TWO_m50    (PONY_GNSS_IO_UBLOX_TWO_m29/(0x01<<21)) // 2^-50
+#define PONY_GNSS_IO_UBLOX_TWO_m55    (PONY_GNSS_IO_UBLOX_TWO_m29/(0x01<<26)) // 2^-55
+#define PONY_GNSS_IO_UBLOX_TWO_m66    (PONY_GNSS_IO_UBLOX_TWO_m55/(0x01<<11)) // 2^-66
+#define PONY_GNSS_IO_UBLOX_PI          3.1415926535898
+#define PONY_GNSS_IO_UBLOX_TWO_m31xPI (PONY_GNSS_IO_UBLOX_TWO_m31*PONY_GNSS_IO_UBLOX_PI) // 2^-31*pi
+#define PONY_GNSS_IO_UBLOX_TWO_m43xPI (PONY_GNSS_IO_UBLOX_TWO_m43*PONY_GNSS_IO_UBLOX_PI) // 2^-43*pi
+char pony_gnss_io_ublox_file_parse_RXM_SFRBX(unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr_buf, void *blk_buf) {
+	
+	enum system_id {gps, glo, gal, bds, sys_count};
+
+	const unsigned char message_version_expected = 0x02;
+	const size_t 
+		max_words = 10, 
+		epoch_eph = 0,
+		freq_eph  = 16;
+
+	static char (*subframe_parser[])(pony_gnss_sat *, pony_gnss_io_ublox_RXM_SFRBX_block *blk) = 
+		{pony_gnss_io_ublox_nav_subframe_parser_gps, pony_gnss_io_ublox_nav_subframe_parser_glo, pony_gnss_io_ublox_nav_subframe_parser_gal, pony_gnss_io_ublox_nav_subframe_parser_bds};
+
+	pony_gnss_io_ublox_RXM_SFRBX_header *hdr	= NULL;
+	pony_gnss_io_ublox_RXM_SFRBX_block  *blk	= NULL;
+	pony_gnss_sat *sat				= NULL;
+	unsigned char i, j, sys, s, maxsat;
+
+	if (cs == NULL || gnss == NULL || fp == NULL || hdr_buf == NULL || blk_buf == NULL)
+		return 0;
+
+	hdr = (pony_gnss_io_ublox_RXM_SFRBX_header *)hdr_buf;
+	blk = (pony_gnss_io_ublox_RXM_SFRBX_block  *)blk_buf;
+
+	// get header data
+	memset(hdr_buf,0,sizeof(*hdr)); // drop to all zeros
+	if ( !fread((void *)(&(hdr->gnssId   )),1,1,fp) ) return 0; // U1: gnss identifier
+	if ( !fread((void *)(&(hdr->svId     )),1,1,fp) ) return 0; // U1: satellite identifier
+	if ( !fread((void *)(&(hdr->reserved1)),1,1,fp) ) return 0; // U1: reserved
+	if ( !fread((void *)(&(hdr->freqId   )),1,1,fp) ) return 0; // U1: GLONASS frequency slot + 7
+	if ( !fread((void *)(&(hdr->numWords )),1,1,fp) ) return 0; // U1: number of data words
+	if ( !fread((void *)(&(hdr->chn      )),1,1,fp) ) return 0; // U1: tracking channel number
+	if ( !fread((void *)(&(hdr->version  )),1,1,fp) ) return 0; // U1: message version
+	if ( !fread((void *)(&(hdr->reserved2)),1,1,fp) ) return 0; // U1: reserved
+	// checksum
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->gnssId   );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->svId     );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->reserved1);
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->freqId   );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->numWords );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->chn      );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->version  );
+	pony_gnss_io_ublox_checksum_recurse(cs,hdr->reserved2);
+	// validate
+	if (hdr->version > message_version_expected) return 0;
+	if (hdr->numWords == 0 || hdr->numWords > max_words) return 0;
+	// process
+	for (sys = 0; sys < sys_count && hdr->gnssId != pony_gnss_io_ublox_signal_id_conversion_table[sys].gnss_id; sys++);
+	if (sys >= sys_count) return 0; // unknown gnss constellation
+	switch (sys) {
+		case gps: if (gnss->gps == NULL) return 0; else sat = gnss->gps->sat; maxsat = (unsigned char)gnss->gps->max_sat_count; break;
+		case glo: if (gnss->glo == NULL) return 0; else sat = gnss->glo->sat; maxsat = (unsigned char)gnss->glo->max_sat_count; break;
+		case gal: if (gnss->gal == NULL) return 0; else sat = gnss->gal->sat; maxsat = (unsigned char)gnss->gal->max_sat_count; break;
+		case bds: if (gnss->bds == NULL) return 0; else sat = gnss->bds->sat; maxsat = (unsigned char)gnss->bds->max_sat_count; break;
+		default : sat = NULL; maxsat = 0;
+	}
+	if (sat == NULL) return 0; // gnss constellation not initialized
+	s = hdr->svId-1;
+	if (s >= maxsat) return 0; // satellite id not supported
+	if (sys == glo)	{ // GLONASS frequency slot
+		gnss->glo->freq_slot[s] = (signed int)hdr->freqId - 7;
+		sat[s].eph[freq_eph] = hdr->freqId - 7;
+	}
+	// subframe data blocks
+	memset(blk_buf,0,sizeof(*blk)); // drop to all zeros
+	for (i = 0; i < hdr->numWords; i++) {
+		// get data
+		if ( !fread((void *)(&(blk->dwrd[i])),4,1,fp) ) return 0; // U4: data word
+		// checksum
+		for (j = 0; j < 32; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(blk->dwrd[i]>>j));
+	}
+	// process
+	if (sat[s].eph[epoch_eph+1] < 1) { // approximate date to resolve gps week number mod 1024, glonass day number, etc.
+		sat[s].eph[epoch_eph+0] = gnss->epoch.Y; 
+		sat[s].eph[epoch_eph+1] = gnss->epoch.M;
+		sat[s].eph[epoch_eph+2] = gnss->epoch.D;
+	}
+	return (subframe_parser[sys])(&(sat[s]), blk);
+
+}
+	// RXM-SFRB: GPS broadcast navigation data subframe
+#define PONY_GNSS_IO_UBLOX_RXM_EPH_MAX_TOTAL_CONVERSION_ENTRIES 12
+char pony_gnss_io_ublox_file_parse_RXM_EPH(unsigned char *cs, pony_gnss *gnss, FILE *fp, void *hdr_buf, void *blk_buf) {
+	
+	const unsigned char 
+		alert_flag_bit = 12, alert_eph = 29,	// alert flag
+		eph_counter_full = 0x07;
+	const double 
+		URA_sqrt2minus1 = 0.41,
+		alert_value	= 8192;
+	const int wk_rollover = 0x0400;
+	const size_t 
+		    max_words   = 8,
+			max_frames  = 3,
+		  epoch_eph     = 0,
+		    toc_entry   = 7,
+		   week_entry   = 1,
+		    SVa_entry   = 3,
+		entries_count[] = {11, 9, 9};  // least significant bits entries count (extra msb-s not included)
+	// conversion tables as in Section 20.3 of GPS Interface Specifications IS-GPS-200J (22 May 2018), p. 77
+	const pony_gnss_io_ublox_nav_subframe_conversion_entry ctable[][PONY_GNSS_IO_UBLOX_RXM_EPH_MAX_TOTAL_CONVERSION_ENTRIES] = { {
+		// subframe 1 entries (Table 20-I, IS-GPS-200J (22 May 2018), p. 95
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   0,   12,   2, UINT_MAX,                              1, 26      }, //  0 Code on L2
+		{   0,   14,  10, UINT_MAX,                              1, 27      }, //  1 Week No. (mod 1024)
+		{   1,   23,   1, UINT_MAX,                              1, 28      }, //  2 L2 P data flag
+		{   0,    8,   4, UINT_MAX,                              1, 29      }, //  3 SV accuracy (URA index)
+		{   0,    2,   6, UINT_MAX,                              1, 30      }, //  4 SV health
+		{   4,    0,   8, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31   , 31      }, //  5 T_GD, x 2^-31
+		{   5,   16,   8,       11,                              1, 32      }, //  6 IODC LSB (issue of clock data least significant bits)
+		{   5,    0,  16, UINT_MAX,                           0x10,  5      }, //  7 toc (time of clock data), x 2^4
+		{   6,   16,   8, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m55   ,  8      }, //  8 af2, x 2^-55 
+		{   6,    0,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43   ,  7      }, //  9 af1, x 2^-43
+		{   7,    2,  22, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31   ,  6      }, // 10 af0, x 2^-31
+		// extra entries for MSB sections
+		{   0,    0,   2, UINT_MAX,                              0, UINT_MAX}, // 11 IODC MSB (issue of clock data most significant bits)
+	}, {
+		// subframe 2 entries (Table 20-III, IS-GPS-200J (22 May 2018), p. 103
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   0,   16,   8, UINT_MAX,                              1,  9      }, //  0 IODE (issue of ephemeris data)
+		{   0,    0,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m05   , 10      }, //  1 Crs,        x 2^-29
+		{   1,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 11      }, //  2 Delta n,    x 2^-43 x pi
+		{   2,    0,  24,        9, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 12      }, //  3 M0    LSB,  x 2^-31 x pi
+		{   3,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 13      }, //  4 Cuc,        x 2^-29
+		{   4,    0,  24,       10,  PONY_GNSS_IO_UBLOX_TWO_m31/4 , 14      }, //  5 e     LSB,  x 2^-33
+		{   5,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 15      }, //  6 Cus,        x 2^-29
+		{   6,    0,  24,       11,  PONY_GNSS_IO_UBLOX_TWO_m19   , 16      }, //  7 sqrtA LSB,  x 2^-33
+		{   7,    8,  16, UINT_MAX,                           0x10, 17      }, //  8 toe (time of ephemeris data)
+		// extra entries for MSB sections			          
+		{   1,    0,   8, UINT_MAX,                              0, UINT_MAX}, //  9 M0    MSB
+		{   3,    0,   8, UINT_MAX,                              0, UINT_MAX}, // 10 e     MSB
+		{   5,    0,   8, UINT_MAX,                              0, UINT_MAX}, // 11 sqrtA MSB
+	}, {
+		// subframe 3 entries (Table 20-III, IS-GPS-200J (22 May 2018), p. 103
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   0,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 18      }, //  0 Cic,        x 2^-29
+		{   1,    0,  24,        9, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 19      }, //  1 Omega0 LSB, x 2^-31 x pi
+		{   2,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 20      }, //  2 Cis,        x 2^-29
+		{   3,    0,  24,       10, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 21      }, //  3 i0     LSB, x 2^-31 x pi
+		{   4,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m05   , 22      }, //  4 Crc,        x 2^-5
+		{   5,    0,  24,       11, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 23      }, //  5 omega  LSB, x 2^-31 x pi
+		{   6,    0,  24, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 24      }, //  6 Omega dot,  x 2^-43 x pi
+		{   7,   16,   8, UINT_MAX,                              1,  9      }, //  7 IODE (issue of ephemeris data)
+		{   7,    2,  14, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 25      }, //  8 idot,       x 2^-43 x pi
+		// extra entries for MSB sections
+		{   0,    0,   8, UINT_MAX,                              0, UINT_MAX}, //  9 Omega0 MSB
+		{   2,    0,   8, UINT_MAX,                              0, UINT_MAX}, // 10 i0     MSB
+		{   4,    0,   8, UINT_MAX,                              0, UINT_MAX}, // 11 omega  MSB
+	} };
+
+	pony_gnss_io_ublox_RXM_EPH_header *hdr	= NULL;
+	pony_gnss_io_ublox_RXM_EPH_block  *blk	= NULL;
+	pony_gnss_sat *sat = NULL;
+	unsigned char sf, i, j;
+	unsigned short N;
+	int week0;
+	pony_time_epoch epoch = {0,0,0,0,0,0};
+
+	if (   gnss           == NULL
+		|| gnss->gps      == NULL
+		|| gnss->gps->sat == NULL
+		|| cs      == NULL 
+		|| fp      == NULL 
+		|| hdr_buf == NULL 
+		|| blk_buf == NULL)
+		return 0;
+
+	hdr = (pony_gnss_io_ublox_RXM_EPH_header *)hdr_buf;
+	blk = (pony_gnss_io_ublox_RXM_EPH_block  *)blk_buf;
+
+	// get header data
+	memset(hdr_buf,0,sizeof(*hdr)); // drop to all zeros
+	if ( !fread((void *)(&(hdr->svid)),4,1,fp) ) return 0; // U4: satellite vehicle identifier
+	if ( !fread((void *)(&(hdr->how )),4,1,fp) ) return 0; // U4: handover word
+	// checksum
+	for (j = 0; j < 32; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(hdr->svid>>j));
+	for (j = 0; j < 32; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(hdr->how >>j));
+	// validate
+	if (hdr->svid == 0 || hdr->svid > gnss->gps->max_sat_count) return 0; // satellite id not supported
+	//if (hdr->how  == 0) return 0; // no ephemeris data is following
+	// subframe data blocks
+	memset(blk_buf,0,sizeof(*blk)); // drop to all zeros
+	for (sf = 0; sf < max_frames; sf++)
+		for (i = 0; i < max_words; i++) {
+			// get data
+			if ( !fread((void *)(&(blk->sf[sf][i])),4,1,fp) ) return 0; // U4: data word
+			// checksum
+			for (j = 0; j < 32; j += 8)	pony_gnss_io_ublox_checksum_recurse(cs,(unsigned char )(blk->sf[sf][i]>>j));
+		}
+	sat = &(gnss->gps->sat[hdr->svid-1]);
+	if (sat->eph[epoch_eph+1] < 1) { // approximate date to resolve gps week number mod 1024, glonass day number, etc.
+		sat->eph[epoch_eph+0] = gnss->epoch.Y; 
+		sat->eph[epoch_eph+1] = gnss->epoch.M;
+		sat->eph[epoch_eph+2] = gnss->epoch.D;
+	}
+	// store current satellite date, if present
+	epoch.Y = pony_gnss_io_ublox_round(sat->eph[epoch_eph+0]);
+	epoch.M = pony_gnss_io_ublox_round(sat->eph[epoch_eph+1]);
+	epoch.D = pony_gnss_io_ublox_round(sat->eph[epoch_eph+2]);
+	if (!pony_time_epoch2gps((unsigned int *)(&week0), NULL, &epoch))
+		week0 = -1;
+	// process
+	for (sf = 0, sat->eph_counter = 0; sf < max_frames; sf++) {
+		// regular data processing
+		if ( !pony_gnss_io_ublox_nav_subframe_parse_data(sat->eph, blk->sf[sf], (pony_gnss_io_ublox_nav_subframe_conversion_entry *)(&(ctable[sf])), entries_count[sf], 1) )
+			return 0;
+		// special entries handling
+		switch (sf+1) { 
+			case 1:
+				// URA index to SV accuracy: SVa = 2^(1+N/2) [N = 0..6], 2^(N-2) [N = 7..15]
+				N = (unsigned short)(sat->eph[ ctable[0][SVa_entry].eph ]);
+				sat->eph[ ctable[0][SVa_entry].eph ] = (N < 7) ? (0x01<<(1 + N/2))*(1 + URA_sqrt2minus1*(N%2)) : (0x01<<(N-2));
+				// toc
+				if (week0 >= 0) {
+					// floor(.5+w0/wr)*wr + mod(w+wr/2,wr)-wr/2 -- closest to week0
+					week0 = pony_gnss_io_ublox_round(((double)week0)/wk_rollover)*wk_rollover + (int)(sat->eph[ ctable[0][week_entry].eph ] + wk_rollover/2)%wk_rollover - wk_rollover/2;
+					sat->eph[ ctable[0][week_entry].eph ] = (double)week0;
+				}
+				else
+					week0 = pony_gnss_io_ublox_round(sat->eph[ ctable[0][week_entry].eph ]);
+				// week number check
+				if (week0 <= 0)
+					return 0;
+				pony_time_gps2epoch(&epoch, (unsigned int)week0, sat->eph[ ctable[0][toc_entry].eph ]);
+				sat->eph[epoch_eph+0] = epoch.Y;
+				sat->eph[epoch_eph+1] = epoch.M;
+				sat->eph[epoch_eph+2] = epoch.D;
+				sat->eph[epoch_eph+3] = epoch.h;
+				sat->eph[epoch_eph+4] = epoch.m;
+				sat->eph[epoch_eph+5] = epoch.s;
+				break;
+			case 2: break;
+			case 3: break;
+		}
+		sat->eph_counter |= (0x01<<sf);
+	}
+	// check whether all subframes have been collected
+	if ((sat->eph_counter & eph_counter_full) == eph_counter_full) {
+		sat->eph_valid = 1;
+		sat->eph_counter = 0;
+	}
+	else
+		sat->eph_valid = 0;
+	// alert flag
+	if ( (hdr->how>>alert_flag_bit) & 0x01 ) {
+		sat->eph[alert_eph] = alert_value; // use at own risk
+		sat->eph_valid = 0; // force no-use
+	}
+
+	return 0;
+
+}
+
+
+
+
+// navigation subframe parsers
+	// single subframe data parser
+char pony_gnss_io_ublox_nav_subframe_parse_data(double *eph, unsigned long *dwrd, 
+									  pony_gnss_io_ublox_nav_subframe_conversion_entry *conversion_table, const size_t entries_count,
+									  const char complement) {
+
+	unsigned long value, mask;
+	size_t i, j;
+
+	if (eph == NULL || dwrd == NULL || conversion_table == NULL || entries_count == 0)
+		return 0; // invalid input
+
+	for (i = 0; i < entries_count; i++) {
+		mask  = ((unsigned long)(-1))>>(sizeof(long)*CHAR_BIT - conversion_table[i].bits);
+		value = ((dwrd[conversion_table[i].wrd])>>(conversion_table[i].shift)) & mask;
+		j = conversion_table[i].msb;
+		if (j < UINT_MAX) {
+			mask   = ((mask+1)<<(conversion_table[j].bits)) - 1;
+			value += (( ((dwrd[conversion_table[j].wrd])>>(conversion_table[j].shift)) & ((0x01<<conversion_table[j].bits)-1) )<<conversion_table[i].bits);
+			value &= mask;
+		}
+		eph[conversion_table[i].eph] = 
+		//      treat as signed                 ? (  sign bit               ?                     two's complement or not      1 bit less :   negative value ) :  as is
+			( ( conversion_table[i].scale < 0 ) ? ( (value & ((mask>>1)+1)) ? (double)(( complement ? (~value + 1) : value ) & (mask>>1)) : -((double)value) ) : (double)value )*conversion_table[i].scale;
+	}
+	return 1;
+
+}
+
+	// GPS subframes
+#define PONY_GNSS_IO_UBLOX_GPS_NAV_SUBFRAME_MAX_TOTAL_CONVERSION_ENTRIES 12
+char pony_gnss_io_ublox_nav_subframe_parser_gps(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe) {
+
+	const unsigned char 
+		tlm_word = 0, tlm_preamble_shift = 22, tlm_preamble = 0x8b, tlm_preamble_mask = 0xff,				// telemetry word
+		how_word = 1, how_alert_flag_bit = 12, how_alert_eph = 29, how_id_shift = 8, how_id_mask = 0x07,	// handover word
+		eph_counter_full = 0x07;
+	const double 
+		URA_sqrt2minus1 = 0.41,
+		how_alert_value	= 8192;
+	const int wk_rollover = 0x0400;
+	const size_t 
+		  epoch_eph     = 0,
+		    IOD_eph     = 9,
+		    toc_entry   = 7,
+		   week_entry   = 1,
+		    SVa_entry   = 3,
+		entries_count[] = {11, 9, 9};  // least significant bits entries count (extra msb-s not included)
+	// conversion tables as in Section 20.3 of GPS Interface Specifications IS-GPS-200J (22 May 2018), p. 77
+	const pony_gnss_io_ublox_nav_subframe_conversion_entry ctable[][PONY_GNSS_IO_UBLOX_GPS_NAV_SUBFRAME_MAX_TOTAL_CONVERSION_ENTRIES] = { {
+		// subframe 1 entries (Table 20-I, IS-GPS-200J (22 May 2018), p. 95
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   2,   18,   2, UINT_MAX,                              1, 26      }, //  0 Code on L2
+		{   2,   20,  10, UINT_MAX,                              1, 27      }, //  1 Week No. (mod 1024)
+		{   3,   29,   1, UINT_MAX,                              1, 28      }, //  2 L2 P data flag
+		{   2,   14,   4, UINT_MAX,                              1, 29      }, //  3 SV accuracy (URA index)
+		{   2,    8,   6, UINT_MAX,                              1, 30      }, //  4 SV health
+		{   6,    6,   8, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31   , 31      }, //  5 T_GD, x 2^-31
+		{   7,   22,   8,       11,                              1, 32      }, //  6 IODC LSB (issue of clock data least significant bits)
+		{   7,    6,  16, UINT_MAX,                           0x10,  5      }, //  7 toc (time of clock data), x 2^4
+		{   8,   22,   8, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m55   ,  8      }, //  8 af2, x 2^-55 
+		{   8,    6,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43   ,  7      }, //  9 af1, x 2^-43
+		{   9,    8,  22, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31   ,  6      }, // 10 af0, x 2^-31
+		// extra entries for MSB sections
+		{   2,    6,   2, UINT_MAX,                              0, UINT_MAX}, // 11 IODC MSB (issue of clock data most significant bits)
+	}, {
+		// subframe 2 entries (Table 20-III, IS-GPS-200J (22 May 2018), p. 103
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   2,   22,   8, UINT_MAX,                              1,  9      }, //  0 IODE (issue of ephemeris data)
+		{   2,    6,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m05   , 10      }, //  1 Crs,        x 2^-29
+		{   3,   14,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 11      }, //  2 Delta n,    x 2^-43 x pi
+		{   4,    6,  24,        9, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 12      }, //  3 M0    LSB,  x 2^-31 x pi
+		{   5,   14,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 13      }, //  4 Cuc,        x 2^-29
+		{   6,    6,  24,       10,  PONY_GNSS_IO_UBLOX_TWO_m31/4 , 14      }, //  5 e     LSB,  x 2^-33
+		{   7,   14,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 15      }, //  6 Cus,        x 2^-29
+		{   8,    6,  24,       11,  PONY_GNSS_IO_UBLOX_TWO_m19   , 16      }, //  7 sqrtA LSB,  x 2^-33
+		{   9,   14,  16, UINT_MAX,                           0x10, 17      }, //  8 toe (time of ephemeris data)
+		// extra entries for MSB sections			          
+		{   3,    6,   8, UINT_MAX,                              0, UINT_MAX}, //  9 M0    MSB
+		{   5,    6,   8, UINT_MAX,                              0, UINT_MAX}, // 10 e     MSB
+		{   7,    6,   8, UINT_MAX,                              0, UINT_MAX}, // 11 sqrtA MSB
+	}, {
+		// subframe 3 entries (Table 20-III, IS-GPS-200J (22 May 2018), p. 103
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   2,   14,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 18      }, //  0 Cic,        x 2^-29
+		{   3,    6,  24,        9, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 19      }, //  1 Omega0 LSB, x 2^-31 x pi
+		{   4,   14,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 20      }, //  2 Cis,        x 2^-29
+		{   5,    6,  24,       10, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 21      }, //  3 i0     LSB, x 2^-31 x pi
+		{   6,   14,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m05   , 22      }, //  4 Crc,        x 2^-5
+		{   7,    6,  24,       11, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 23      }, //  5 omega  LSB, x 2^-31 x pi
+		{   8,    6,  24, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 24      }, //  6 Omega dot,  x 2^-43 x pi
+		{   9,   22,   8, UINT_MAX,                              1,  9      }, //  7 IODE (issue of ephemeris data)
+		{   9,    8,  14, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 25      }, //  8 idot,       x 2^-43 x pi
+		// extra entries for MSB sections
+		{   2,    6,   8, UINT_MAX,                              0, UINT_MAX}, //  9 Omega0 MSB
+		{   4,    6,   8, UINT_MAX,                              0, UINT_MAX}, // 10 i0     MSB
+		{   6,    6,   8, UINT_MAX,                              0, UINT_MAX}, // 11 omega  MSB
+	} };
+
+	unsigned char id;
+	unsigned short N;
+	int week0, IODprev;
+	pony_time_epoch epoch = {0,0,0,0,0,0};
+
+	// store current satellite date, if present
+	epoch.Y = pony_gnss_io_ublox_round(sat->eph[epoch_eph+0]);
+	epoch.M = pony_gnss_io_ublox_round(sat->eph[epoch_eph+1]);
+	epoch.D = pony_gnss_io_ublox_round(sat->eph[epoch_eph+2]);
+	if (!pony_time_epoch2gps((unsigned int *)(&week0), NULL, &epoch))
+		week0 = -1;
+	// store IODE
+	IODprev = pony_gnss_io_ublox_round(sat->eph[IOD_eph]);
+	// tlm word - telemetry
+		// preamble
+	if ( ((subframe->dwrd[tlm_word]>>tlm_preamble_shift) & tlm_preamble_mask) != tlm_preamble ) 
+		return 0;
+	// how word - handover 
+		// subframe id
+	id = (subframe->dwrd[how_word]>>how_id_shift) & how_id_mask;
+	// regular data processing
+	if (id < 1 || id > 3) return 0; // subframe id invalid or not supported
+	if ( !pony_gnss_io_ublox_nav_subframe_parse_data(sat->eph, subframe->dwrd, (pony_gnss_io_ublox_nav_subframe_conversion_entry *)(&(ctable[id-1])), entries_count[id-1], 1) )
+		return 0;
+	// special entries handling
+	switch (id) { 
+		case 1:
+			// URA index to SV accuracy: SVa = 2^(1+N/2) [N = 0..6], 2^(N-2) [N = 7..15]
+			N = (unsigned short)(sat->eph[ ctable[0][SVa_entry].eph ]);
+			sat->eph[ ctable[0][SVa_entry].eph ] = (N < 7) ? (0x01<<(1 + N/2))*(1 + URA_sqrt2minus1*(N%2)) : (0x01<<(N-2));
+			// toc
+			if (week0 >= 0) {
+				// floor(.5+w0/wr)*wr + mod(w+wr/2,wr)-wr/2 -- closest to week0
+				week0 = pony_gnss_io_ublox_round(((double)week0)/wk_rollover)*wk_rollover + (int)(sat->eph[ ctable[0][week_entry].eph ] + wk_rollover/2)%wk_rollover - wk_rollover/2;
+				sat->eph[ ctable[0][week_entry].eph ] = (double)week0;
+			}
+			else
+				week0 = pony_gnss_io_ublox_round(sat->eph[ ctable[0][week_entry].eph ]);
+			// week number check
+			if (week0 <= 0)
+				return 0;
+			pony_time_gps2epoch(&epoch, (unsigned int)week0, sat->eph[ ctable[0][toc_entry].eph ]);
+			sat->eph[epoch_eph+0] = epoch.Y;
+			sat->eph[epoch_eph+1] = epoch.M;
+			sat->eph[epoch_eph+2] = epoch.D;
+			sat->eph[epoch_eph+3] = epoch.h;
+			sat->eph[epoch_eph+4] = epoch.m;
+			sat->eph[epoch_eph+5] = epoch.s;
+			break;
+		case 2: break;
+		case 3: break;
+	}
+	// check whether all subframes have been collected
+	if (IODprev != pony_gnss_io_ublox_round(sat->eph[IOD_eph])) {// new issue of data has started
+		sat->eph_valid = 0;   // stop using the satellite
+		sat->eph_counter = 0;
+	}
+	sat->eph_counter |= (0x01<<(id-1));
+	if ((sat->eph_counter & eph_counter_full) == eph_counter_full) {
+		sat->eph_valid = 1;
+		sat->eph_counter = 0;
+	}
+	// alert flag
+	if ( (subframe->dwrd[how_word]>>how_alert_flag_bit) & 0x01 ) {
+		sat->eph[how_alert_eph] = how_alert_value; // use at own risk
+		sat->eph_valid = 0; // force no-use
+	}
+
+	return 1;
+}
+
+	// GLONASS subframes
+#define PONY_GNSS_IO_UBLOX_GLO_NAV_SUBFRAME_MAX_TOTAL_CONVERSION_ENTRIES 7
+char pony_gnss_io_ublox_nav_subframe_parser_glo(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe) {
+
+	const double dt_utc_h = 3, dt_utc_s = dt_utc_h*3600;
+	const unsigned char 
+		msg_id_shift		= 27,
+		tb_shift            = 14,
+		NT_shift            = 21,
+		eph_counter_full	= 0x0f;
+	const unsigned long
+		tb_mask = 0x007f,
+		NT_mask = 0x07ff;
+	const size_t        msg_id_word		= 0,
+						epoch_eph		= 0,
+						tau_entry		= 0,
+						tb_entry		= 1,
+						NT_entry		= 2,
+						tk_s_entry		= 0,
+						tk_h_entry		= 1,
+						tk_eph			= 8,
+						entries_count[]	= {5, 5, 4, 3};  // least significant bits entries count (extra msb-s not included)
+	// conversion tables as in Section 4.3.2 of GLONASS Interface Control Document ICD L1,L2 GLONASS Edition 5.1 2008, p. 27
+	const pony_gnss_io_ublox_nav_subframe_conversion_entry ctable[][PONY_GNSS_IO_UBLOX_GLO_NAV_SUBFRAME_MAX_TOTAL_CONVERSION_ENTRIES] = { {
+		// string 1 entries (Table 4.5, ICD L1,L2 GLONASS Ed. 5.1 2008, p. 32)
+		// wrd shift bits msb_entry_index                   scale  eph
+		{   0,   11,   7, UINT_MAX,                            30,  5      }, //  0 tk sec, x 30
+		{   0,   18,   5, UINT_MAX,                             1,  3      }, //  1 tk hours
+		{   1,   19,  13,        5, -PONY_GNSS_IO_UBLOX_TWO_m19/2, 10      }, //  2 Vx LSB, x 2^-20
+		{   1,   14,   5, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29/2, 11      }, //  3 Ax,     x 2^-30
+		{   2,   19,  13,        6, -PONY_GNSS_IO_UBLOX_TWO_m11  ,  9      }, //  4 X  LSB, x 2^-11
+		// extra entries for MSB sections
+		{   0,    0,  11, UINT_MAX,                             0, UINT_MAX}, //  5 Vx MSB
+		{   1,    0,  14, UINT_MAX,                             0, UINT_MAX}, //  6 X  MSB
+	}, {
+		// string 2 entries (Table 4.5, ICD L1,L2 GLONASS Ed. 5.1 2008, p. 32)
+		// wrd shift bits msb_entry_index                   scale  eph
+		{   0,   24,   3, UINT_MAX,                             1, 12      }, //  0 B
+		{   0,   16,   7, UINT_MAX,                            15,  4      }, //  1 tb,     x 15
+		{   1,   19,  13,        5, -PONY_GNSS_IO_UBLOX_TWO_m19/2, 14      }, //  2 Vy LSB, x 2^-20
+		{   1,   14,   5, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29/2, 15      }, //  3 Ay,     x 2^-30
+		{   2,   19,  13,        6, -PONY_GNSS_IO_UBLOX_TWO_m11  , 13      }, //  4 Y  LSB, x 2^-11
+		// extra entries for MSB sections
+		{   0,    0,  11, UINT_MAX,                           0  , UINT_MAX}, //  5 Vy MSB
+		{   1,    0,  14, UINT_MAX,                           0  , UINT_MAX}, //  6 Y  MSB
+	}, {
+		// string 3 entries (Table 4.5, ICD L1,L2 GLONASS Ed. 5.1 2008, p. 32)
+		// wrd shift bits msb_entry_index                   scale  eph
+		{   0,   15,  11, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m40  ,  7      }, //  0 gamma,  x 2^-40
+		{   1,   19,  13,        4, -PONY_GNSS_IO_UBLOX_TWO_m19/2, 18      }, //  1 Vz LSB, x 2^-20
+		{   1,   14,   5, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29/2, 19      }, //  2 Az,     x 2^-30
+		{   2,   19,  13,        5, -PONY_GNSS_IO_UBLOX_TWO_m11  , 17      }, //  3 Z  LSB, x 2^-11
+		// extra entries for MSB sections				  
+		{   0,    0,  11, UINT_MAX,                             0, UINT_MAX}, //  4 Vz MSB
+		{   1,    0,  14, UINT_MAX,                             0, UINT_MAX}, //  5 Z  MSB
+	}, {
+		// string 4 entries (Table 4.5, ICD L1,L2 GLONASS Ed. 5.1 2008, p. 32)
+		// wrd shift bits msb_entry_index                   scale  eph
+		{   0,    5,  22, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29/2,  6      }, //  0 tau,    x 2^-30
+		{   1,   27,   5, UINT_MAX,                             1, 20      }, //  1 E
+		{   2,   26,   6,        3,                             1,  2      }, //  2 NT LSB
+		// extra entries for MSB sections				        
+		{   1,    0,   5, UINT_MAX,                             0, UINT_MAX}, //  3 NT MSB
+	} };
+
+	unsigned char id;
+	long tk_prev;
+	pony_time_epoch epoch;
+
+	// store current satellite date, if present
+	epoch.Y = pony_gnss_io_ublox_round(sat->eph[epoch_eph+0]);
+	epoch.M = pony_gnss_io_ublox_round(sat->eph[epoch_eph+1]);
+	epoch.D = pony_gnss_io_ublox_round(sat->eph[epoch_eph+2]);
+	// store tb
+	epoch.h = pony_gnss_io_ublox_round(sat->eph[epoch_eph+3]);
+	epoch.m = pony_gnss_io_ublox_round(sat->eph[epoch_eph+4]);
+	epoch.s = pony_gnss_io_ublox_round(sat->eph[epoch_eph+5]);
+	// store tk
+	tk_prev = pony_gnss_io_ublox_round(sat->eph[tk_eph]);
+	// message string id
+	id = (subframe->dwrd[msg_id_word]>>msg_id_shift) & 0x0f;
+	// regular data processing
+	if (id < 1 || id > 4) return 0; // message id invalid or not supported
+	if ( !pony_gnss_io_ublox_nav_subframe_parse_data(sat->eph, subframe->dwrd, (pony_gnss_io_ublox_nav_subframe_conversion_entry *)(&(ctable[id-1])), entries_count[id-1], 0) )
+		return 0;
+	// special entries handling
+	switch (id) {
+		case 1:
+			// tk + nd*86400 (seconds into utc week)
+			pony_time_epoch2gps(NULL, &(sat->eph[tk_eph]), &epoch); // secondsi nto week
+			sat->eph[tk_eph] -= epoch.h*3600 + epoch.m*60 + epoch.s; // from day beginning
+			sat->eph[tk_eph] += sat->eph[ ctable[0][tk_h_entry].eph ]*3600 + sat->eph[ ctable[0][tk_s_entry].eph ];
+			sat->eph[tk_eph] -= dt_utc_s;	// to UTC
+			if (sat->eph[tk_eph] < 0)		// week rollover
+				sat->eph[tk_eph] += pony->gnss_const.sec_in_w;
+			// restore tb
+			sat->eph[ ctable[0][tk_h_entry].eph ] = epoch.h, sat->eph[ ctable[0][tk_s_entry].eph ] = epoch.s;
+			break;
+		case 2:
+			// copy tb to eph_counter bitfield and restore satellite time until full subframe set is collected
+			sat->eph_counter &= ~(tb_mask<<tb_shift); // drop bits
+			sat->eph_counter |= pony_gnss_io_ublox_round(sat->eph[ ctable[1][tb_entry].eph ]/ctable[1][tb_entry].scale)<<tb_shift;
+			sat->eph[ ctable[1][tb_entry].eph ] = epoch.m;
+			break;
+		case 3: break;
+		case 4: 
+			// tauN x -1
+			sat->eph[ ctable[3][tau_entry].eph ] *= -1; 
+			// copy NT to eph_counter bitfield and restore satellite date until full subframe set is collected
+			sat->eph_counter &= ~(NT_mask<<NT_shift); // drop bits
+			sat->eph_counter |= (unsigned long)(pony_gnss_io_ublox_round(sat->eph[ ctable[3][NT_entry].eph ]/ctable[3][NT_entry].scale))<<NT_shift;
+			sat->eph[ ctable[3][NT_entry].eph ] = epoch.D;
+			break;
+	}
+	// check whether all subframes have been collected
+	if (tk_prev != pony_gnss_io_ublox_round(sat->eph[tk_eph]))
+		sat->eph_counter &= ~eph_counter_full; // new dataset has started, reset counting bits
+	sat->eph_counter |= (0x01<<(id-1));
+	if ((sat->eph_counter & eph_counter_full) == eph_counter_full) {
+		// tb from ephemeris counter bitfield
+		sat->eph[ ctable[1][tb_entry].eph ] = ((sat->eph_counter>>tb_shift) & tb_mask)*ctable[1][tb_entry].scale;
+		// NT from ephemeris counter bitfield
+		sat->eph[ ctable[3][NT_entry].eph ] = ((sat->eph_counter>>NT_shift) & NT_mask)*ctable[3][NT_entry].scale;
+		// tb to time of day
+		sat->eph[epoch_eph+3] = pony_gnss_io_ublox_round(sat->eph[ ctable[1][tb_entry].eph ])/60 - dt_utc_h;	// hours in UTC
+		sat->eph[epoch_eph+4] = pony_gnss_io_ublox_round(sat->eph[ ctable[1][tb_entry].eph ])%60;				// minutes
+		sat->eph[epoch_eph+5] = 0;																		// seconds
+		// day rollover handling
+		if (sat->eph[epoch_eph+3] < 0) {
+			sat->eph[epoch_eph+3] += 24;
+			sat->eph[ ctable[3][NT_entry].eph ] -= 1;
+			if (sat->eph[ ctable[3][NT_entry].eph ] < 1) { // 4-year cycle rollover
+				sat->eph[ ctable[3][NT_entry].eph ] += 1461;
+				epoch.Y -= 4;
+			}
+		}
+		// NT to date
+		pony_gnss_io_ublox_glonass_day2date(&epoch, pony_gnss_io_ublox_round(sat->eph[ ctable[3][NT_entry].eph ]));
+		sat->eph[epoch_eph+0] = epoch.Y, sat->eph[epoch_eph+1] = epoch.M, sat->eph[epoch_eph+2] = epoch.D;
+		// ephemeris validity flag
+		sat->eph_valid = 1;
+		// drop the counter
+		sat->eph_counter = 0;
+	}
+
+	return 1;
+}
+
+	// Galileo subframes I/NAV E1-B/E5b-I
+#define PONY_GNSS_IO_UBLOX_GAL_NAV_SUBFRAME_MAX_TOTAL_CONVERSION_ENTRIES 12
+char pony_gnss_io_ublox_nav_subframe_parser_gal(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe) {
+
+	const unsigned char 
+		even_word         = 0,
+		 odd_word         = 4,
+		even_odd_shift    = 31,
+		msg_type_word     = 0,
+		msg_type_shift    = 24,
+		msg_type_mask     = 0x3f,
+		health_bits_count = 6, 
+		eph_counter_full  = 0x1f;
+	const unsigned short 
+		wk_rollover = 0x1000, // GST/GAL week rollover interval
+		wk_shift    = 0x0400, // GST week shift to align with GPS week
+		DS_bitfield = 0x0201; // data source I/NAV E1-B, bit 0 and bit 9 set
+	const size_t 
+		  epoch_eph  = 0,
+		     DS_eph  = 26,
+		    IOD_eph  = 9,
+		  SISA_entry = 7,
+		   toc_entry = 3,
+		  week_entry = 3,
+		health_entry = 2,
+		entries_count[] = {5, 5, 8, 7, 5};  // least significant bits entries count (extra msb-s not included)
+	// conversion tables as in Sections 4.3.5 and 5.1 of Galileo Open Service Signal In Space Interface Control Document OS-SIS-ICD, Issue 1.2 (November 2015), pp. 37, 43
+	const pony_gnss_io_ublox_nav_subframe_conversion_entry ctable[][PONY_GNSS_IO_UBLOX_GAL_NAV_SUBFRAME_MAX_TOTAL_CONVERSION_ENTRIES] = { {
+		// I/NAV word type 1 entries (Table 39, OS-SIS-ICD, Issue 1.2 (November 2015), p. 37
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   0,   14,  10, UINT_MAX,                              1,  9      }, //  0 IODnav
+		{   0,    0,  14, UINT_MAX,                             60, 17      }, //  1 toe,       x 60
+		{   1,    0,  32, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 12      }, //  2 M0,        x 2^-31 x pi
+		{   2,    0,  32, UINT_MAX,  PONY_GNSS_IO_UBLOX_TWO_m31/4 , 14      }, //  3 e,         x 2^-33
+		{   4,   16,  14,        5,  PONY_GNSS_IO_UBLOX_TWO_m19   , 16      }, //  4 sqrtA LSB, x 2^-19
+		// extra entries for MSB sections										  
+		{   3,   14,  18, UINT_MAX,                              0, UINT_MAX}, //  5 sqrtA MSB
+	}, {
+		// I/NAV word type 2 entries (Table 40, OS-SIS-ICD, Issue 1.2 (November 2015), p. 37
+		// wrd shift bits msb                                scale  eph
+		{   0,   14,  10, UINT_MAX,                              1,  9      }, //  0 IODnav
+		{   1,   14,  18,        5, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 19      }, //  1 Om0   LSB, x 2^-31 x pi
+		{   2,   14,  18,        6, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 21      }, //  2 i0    LSB, x 2^-31 x pi
+		{   3,   14,  18,        7, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 23      }, //  3 omega LSB, x 2^-31 x pi
+		{   4,   16,  14, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 25      }, //  4 idot,      x 2^-43 x pi
+		// extra entries for MSB sections										  
+		{   0,    0,  14, UINT_MAX,                              0, UINT_MAX}, //  5 Om0   MSB
+		{   1,    0,  14, UINT_MAX,                              0, UINT_MAX}, //  6 i0    MSB
+		{   2,    0,  14, UINT_MAX,                              0, UINT_MAX}, //  7 omega MSB
+	}, {
+		// I/NAV word type 3 entries (Table 41, OS-SIS-ICD, Issue 1.2 (November 2015), p. 38
+		// wrd shift bits msb                                scale  eph
+		{   0,   14,  10, UINT_MAX,                              1,  9      }, //  0 IODnav
+		{   1,   22,  10,        8, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 24      }, //  1 Omdot LSB, x 2^-43 x pi
+		{   1,    6,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 11      }, //  2 Delta n,   x 2^-43 x pi
+		{   2,   22,  10,        9, -PONY_GNSS_IO_UBLOX_TWO_m29   , 13      }, //  3 Cuc   LSB, x 2^-29
+		{   2,    6,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 15      }, //  4 Cus,       x 2^-29
+		{   3,   22,  10,       10, -PONY_GNSS_IO_UBLOX_TWO_m05   , 22      }, //  5 Crc   LSB, x 2^-5
+		{   4,   22,   8,       11, -PONY_GNSS_IO_UBLOX_TWO_m05   , 10      }, //  6 Crs   LSB, x 2^-5
+		{   4,   14,   8, UINT_MAX,                              1, 29      }, //  7 SISA
+		// extra entries for MSB sections										  
+		{   0,    0,  14, UINT_MAX,                              0, UINT_MAX}, //  8 Omdot MSB
+		{   1,    0,   6, UINT_MAX,                              0, UINT_MAX}, //  9 Cuc   MSB
+		{   2,    0,   6, UINT_MAX,                              0, UINT_MAX}, // 10 Crc   MSB
+		{   3,   14,   8, UINT_MAX,                              0, UINT_MAX}, // 11 Crs   MSB
+	}, {
+		// I/NAV word type 4 entries (Table 42, OS-SIS-ICD, Issue 1.2 (November 2015), p. 38
+		// wrd shift bits msb                                scale  eph
+		{   0,   14,  10, UINT_MAX,                              1,  9      }, //  0 IODnav
+		{   1,   24,   8,        7, -PONY_GNSS_IO_UBLOX_TWO_m29   , 18      }, //  1 Cic   LSB, x 2^-29
+		{   1,    8,  16, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m29   , 20      }, //  2 Cis,       x 2^-29
+		{   2,   26,   6,        8,                             60,  5      }, //  3 toc   LSB, x 60
+		{   3,   27,   5,        9, -PONY_GNSS_IO_UBLOX_TWO_m31/8 ,  6      }, //  4 af0   LSB, x 2^-34
+		{   4,   22,   8,       10, -PONY_GNSS_IO_UBLOX_TWO_m43/8 ,  7      }, //  5 af1   LSB, x 2^-46
+		{   4,   16,   6, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m55/16,  8      }, //  6 af2,       x 2^-59
+		// extra entries for MSB sections										  
+		{   0,    0,   8, UINT_MAX,                              0, UINT_MAX}, //  7 Cic   MSB
+		{   1,    0,   8, UINT_MAX,                              0, UINT_MAX}, //  8 toc   MSB
+		{   2,    0,  26, UINT_MAX,                              0, UINT_MAX}, //  9 af0   MSB
+		{   3,   14,  13, UINT_MAX,                              0, UINT_MAX}, // 10 af1   MSB
+	}, {
+		// I/NAV word type 5 entries (Table 43, OS-SIS-ICD, Issue 1.2 (November 2015), p. 38
+		// wrd shift bits msb                                scale  eph
+		{   1,    5,  10, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31/2 , 31      }, //  0 BGD(E1/E5a),     x 2^-32
+		{   2,   27,   5,        5, -PONY_GNSS_IO_UBLOX_TWO_m31/2 , 32      }, //  1 BGD(E1,E5b) LSB, x 2^-32
+		{   2,   21,   6, UINT_MAX,                              1, 30      }, //  2 health flags
+		{   2,    9,  12, UINT_MAX,                              1, 27      }, //  3 WN
+		{   3,   21,  11,        6,                              1, 33      }, //  4 TOW         LSB
+		// extra entries for MSB sections				  	      					    
+		{   1,    0,   5, UINT_MAX,                              0, UINT_MAX}, //  5 BGD(E1,E5b) MSB
+		{   2,    0,   9, UINT_MAX,                              0, UINT_MAX}, //  6 TOW         MSB
+	} };
+
+	unsigned char id;
+	unsigned short health_bits = 0;
+	int week0, IODprev;
+	double SISA;
+	pony_time_epoch epoch = {0,0,0,0,0,0};
+
+	// store current satellite date, if present
+	epoch.Y = pony_gnss_io_ublox_round(sat->eph[epoch_eph+0]);
+	epoch.M = pony_gnss_io_ublox_round(sat->eph[epoch_eph+1]);
+	epoch.D = pony_gnss_io_ublox_round(sat->eph[epoch_eph+2]);
+	epoch.h = pony_gnss_io_ublox_round(sat->eph[epoch_eph+3]);
+	epoch.m = pony_gnss_io_ublox_round(sat->eph[epoch_eph+4]);
+	epoch.s = pony_gnss_io_ublox_round(sat->eph[epoch_eph+5]);
+	if (!pony_time_epoch2gps((unsigned int *)(&week0), NULL, &epoch))
+		week0 = -1;
+	// store IODnav
+	IODprev = pony_gnss_io_ublox_round(sat->eph[IOD_eph]);
+	// check even/odd bits
+	if ( ((subframe->dwrd[even_word]>>even_odd_shift) & 0x01) != 0 || ((subframe->dwrd[odd_word]>>even_odd_shift) & 0x01) != 1 ) 
+		return 0;
+	// message type id
+	id = (subframe->dwrd[msg_type_word]>>msg_type_shift) & msg_type_mask;
+	// regular data processing
+	if (id < 1 || id > 5) return 0; // subframe id invalid or not supported
+	if ( !pony_gnss_io_ublox_nav_subframe_parse_data(sat->eph, subframe->dwrd, (pony_gnss_io_ublox_nav_subframe_conversion_entry *)(&(ctable[id-1])), entries_count[id-1], 1) )
+		return 0;
+	// special entries handling
+	switch (id) { 
+		case 1: break;
+		case 2: break;
+		case 3:  
+			// SISA index to signal in space accuracy 
+			SISA = sat->eph[ ctable[2][SISA_entry].eph ];
+			sat->eph[ ctable[2][SISA_entry].eph ] = 
+				  (SISA <=  50) ? (       SISA     *0.01) : 
+				( (SISA <=  75) ? (0.5 + (SISA- 50)*0.02) : 
+				( (SISA <= 100) ? (1.0 + (SISA- 75)*0.04) : 
+				( (SISA <= 125) ? (2.0 + (SISA-100)*0.16) : -1) ) ); // -1 for NAPA state - no accuracy prediction available
+			break;
+		case 4: 
+			// toc seconds to time of day and date, if available
+			if (week0 < 0) { // no date available
+				// remove whole days
+				sat->eph[ ctable[3][toc_entry].eph ] -= ((int)(sat->eph[ ctable[3][toc_entry].eph ]/pony->gnss_const.sec_in_d))*pony->gnss_const.sec_in_d;
+				// hours
+				sat->eph[epoch_eph+3] = (int)(sat->eph[ ctable[3][toc_entry].eph ]/3600);
+				// remove whole hours
+				sat->eph[ ctable[3][toc_entry].eph ] -= sat->eph[epoch_eph+3]*3600;
+				// minutes
+				sat->eph[epoch_eph+4] = (int)(sat->eph[ ctable[3][toc_entry].eph ]/60);
+				// seconds
+				sat->eph[epoch_eph+5] = sat->eph[ ctable[3][toc_entry].eph ] - sat->eph[epoch_eph+4]*60;
+			}
+			else {
+				pony_time_gps2epoch(&epoch, week0, sat->eph[ ctable[3][toc_entry].eph ]);
+				sat->eph[epoch_eph+0] = epoch.Y;
+				sat->eph[epoch_eph+1] = epoch.M;
+				sat->eph[epoch_eph+2] = epoch.D;
+				sat->eph[epoch_eph+3] = epoch.h;
+				sat->eph[epoch_eph+4] = epoch.m;
+				sat->eph[epoch_eph+5] = epoch.s;
+			}
+			break;
+		case 5: 
+			// GST week to GAL week (aligned to GPS week)
+			sat->eph[ ctable[4][week_entry].eph ] += wk_shift;
+			if (week0 >= 0) {
+				// floor(.5+w0/wr)*wr + mod(w+wr/2,wr)-wr/2 -- closest to week0
+				week0 = pony_gnss_io_ublox_round(((double)week0)/wk_rollover)*wk_rollover + ((int)(sat->eph[ ctable[4][week_entry].eph ]) + wk_rollover/2)%wk_rollover - wk_rollover/2;
+				sat->eph[ ctable[4][week_entry].eph ] = (double)week0;
+			}
+			else
+				week0 = pony_gnss_io_ublox_round(sat->eph[ ctable[4][week_entry].eph ]);
+			// week number check
+			if (week0 <= 0)
+				return 0;
+			// recalculate toc
+			pony_time_epoch2gps(NULL, &(sat->eph[ ctable[3][toc_entry].eph ]), &epoch);
+			pony_time_gps2epoch(&epoch, (unsigned int)week0, sat->eph[ ctable[3][toc_entry].eph ]);
+			sat->eph[epoch_eph+0] = epoch.Y;
+			sat->eph[epoch_eph+1] = epoch.M;
+			sat->eph[epoch_eph+2] = epoch.D;
+			sat->eph[epoch_eph+3] = epoch.h;
+			sat->eph[epoch_eph+4] = epoch.m;
+			sat->eph[epoch_eph+5] = epoch.s;
+			// health bits
+			health_bits = (unsigned short)(pony_gnss_io_ublox_round(sat->eph[ ctable[4][health_entry].eph ]));
+			health_bits  |= (health_bits&0x01)<< health_bits_count;   // bit  0 remains in place, move to MSB
+			health_bits  |= (health_bits&0x0c)<<(health_bits_count-1); // bits 2-3 to bits 1-2, move to MSB
+			health_bits  |= (health_bits&0x02)<<(health_bits_count+5); // bit  1 to bit 6, move to MSB
+			health_bits  |= (health_bits&0x30)<<(health_bits_count+3); // bits 4-5 to bits 7-8, move to MSB
+			sat->eph[ ctable[4][health_entry].eph ] = (double)(health_bits>>health_bits_count); // move back to LSB
+			break;
+	}
+	// check whether all subframes have been collected
+	if (IODprev != pony_gnss_io_ublox_round(sat->eph[IOD_eph])) {// new issue of data has started
+		sat->eph_valid = 0;   // stop using the satellite
+		sat->eph_counter = 0;
+	}
+	sat->eph_counter |= (0x01<<(id-1));
+	if ((sat->eph_counter & eph_counter_full) == eph_counter_full) {
+		sat->eph_valid = 1;
+		sat->eph_counter = 0; // drop the counter
+	}
+	// data source flags
+	sat->eph[DS_eph] = (double)((short)(sat->eph[DS_eph]) | DS_bitfield); // set E1-B and bit 9
+
+	return 1;
+
+}
+
+	// BeiDou subframes
+#define PONY_GNSS_IO_UBLOX_BDS_NAV_SUBFRAME_MAX_TOTAL_CONVERSIION_ENTRIES 18
+char pony_gnss_io_ublox_nav_subframe_parser_bds(pony_gnss_sat *sat, pony_gnss_io_ublox_RXM_SFRBX_block *subframe) {
+
+	const unsigned char 
+		eph_counter_full = 0x07,
+		toe_MSB_shift    = 30,
+		toe_LSB_shift    = 15;
+	const unsigned long
+		toe_MSB_mask = 0x0003,
+		toe_LSB_mask = 0x7fff;
+	const unsigned short
+		pre_word = 0, pre_shift = 19, pre_mask = 0x07ff, preamble = 0x0712, // preamble
+		fra_word = 0, fra_shift = 12, fra_mask = 0x0007,					// frame id
+		wk_shift = 1356, wk_rollover = 0x2000;
+	const double 
+		URA_sqrt2minus1 = 0.41;
+	const size_t 
+		  epoch_eph     = 0,
+		    toe_eph     = 17,
+		   URAI_entry   = 3,
+		   week_entry   = 4,
+		    toc_entry   = 5,
+		toe_MSB_entry   = 9,
+		toe_LSB_entry   = 1,
+		entries_count[] = {12, 10, 9};  // least significant bits entries count (extra msb-s not included)
+	// conversion tables as in Section 5.2.4 of BeiDou Interface Control Document BDS-SIS-ICD-2.1 (November 2016), p. 23
+	const pony_gnss_io_ublox_nav_subframe_conversion_entry ctable[][PONY_GNSS_IO_UBLOX_BDS_NAV_SUBFRAME_MAX_TOTAL_CONVERSIION_ENTRIES] = { {
+		// subframe 1 entries (Tables 5-4, 5-6, 5-7, 5-8 of BDS-SIS-ICD-2.1 (November 2016), p. 23
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   1,   18,  12,       12,                              1, 33      }, //  0 SOW     LSB  (seconds of BDS week least significant bits)
+		{   1,   17,   1, UINT_MAX,                              1, 30      }, //  1 SatH1        (health flag)
+		{   1,   12,   5, UINT_MAX,                              1, 34      }, //  2 AODC         (age of data - clock)
+		{   1,    8,   4, UINT_MAX,                              1, 29      }, //  3 URAI         (user range accuracy indicator)
+		{   2,   17,  13, UINT_MAX,                              1, 27      }, //  4 WN           (BDS week number)
+		{   3,   22,   8,       13,                              8,  5      }, //  5 toc,         x 8
+		{   3,   12,  10, UINT_MAX,                         -1e-10, 31      }, //  6 TGD1,        x 0.1 nsec
+		{   4,   24,   6,       14,                         -1e-10, 32      }, //  7 TGD2,        x 0.1 nsec
+		{   7,   15,  11, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m66   ,  8      }, //  8 a2,          x 2^-66
+		{   8,   13,  17,       15, -PONY_GNSS_IO_UBLOX_TWO_m31/4 ,  6      }, //  9 a0      LSB, x 2^-33
+		{   9,   13,  17,       16, -PONY_GNSS_IO_UBLOX_TWO_m50   ,  7      }, // 10 a1      LSB, x 2^-50
+		{   9,    8,   5, UINT_MAX,                              1,  9      }, // 11 AODE         (age of data - ephemeris)
+		// extra entries for MSB sections			  	      						 	    
+		{   0,    4,   8, UINT_MAX,                              0, UINT_MAX}, // 12 SOW     MSB  (seconds of BDS week most significant bits)
+		{   2,    8,   9, UINT_MAX,                              0, UINT_MAX}, // 13 toc     MSB
+		{   3,    8,   4, UINT_MAX,                              0, UINT_MAX}, // 14 TGD2    MSB
+		{   7,    8,   7, UINT_MAX,                              0, UINT_MAX}, // 15 a0      MSB
+		{   8,    8,   5, UINT_MAX,                              0, UINT_MAX}, // 16 a1      MSB
+	}, {
+		// subframe 2 entries (Table 5-10 of BDS-SIS-ICD-2.1 (November 2016), p. 34
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   1,   18,  12,       10,                              1, 33      }, //  0 SOW     LSB  (seconds of BDS week least significant bits)
+		{   2,   24,   6,       11, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 11      }, //  1 Delta n LSB, x 2^-43 x pi
+		{   3,   28,   2,       12, -PONY_GNSS_IO_UBLOX_TWO_m31   , 13      }, //  2 Cuc     LSB, x 2^-31
+		{   4,   18,  12,       13, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 12      }, //  3 M0      LSB, x 2^-31 x pi
+		{   5,    8,  22,       14, +PONY_GNSS_IO_UBLOX_TWO_m31/4 , 14      }, //  4 e       LSB, x 2^-33
+		{   6,   12,  18, UINT_MAX, -PONY_GNSS_IO_UBLOX_TWO_m31   , 15      }, //  5 Cus     LSB, x 2^-31
+		{   7,   16,  14,       15, -PONY_GNSS_IO_UBLOX_TWO_m05/2 , 22      }, //  6 Crc     LSB, x 2^-6
+		{   8,   20,  10,       16, -PONY_GNSS_IO_UBLOX_TWO_m05/2 , 10      }, //  7 Crs     LSB, x 2^-6
+		{   9,   10,  20,       17, +PONY_GNSS_IO_UBLOX_TWO_m19   , 16      }, //  8 sqrtA   LSB, x 2^-19
+		{   9,    8,   2, UINT_MAX,                   (0x01<<15)*8, 17      }, //  9 toe     MSB, x 8*2^15
+		// extra entries for MSB sections											   
+		{   0,    4,   8, UINT_MAX,                              0, UINT_MAX}, // 10 SOW     MSB  (seconds of BDS week most significant bits)
+		{   1,    8,  10, UINT_MAX,                              0, UINT_MAX}, // 11 Delta n MSB
+		{   2,    8,  16, UINT_MAX,                              0, UINT_MAX}, // 12 Cuc     MSB
+		{   3,    8,  20, UINT_MAX,                              0, UINT_MAX}, // 13 M0      MSB
+		{   4,    8,  10, UINT_MAX,                              0, UINT_MAX}, // 14 e       MSB
+		{   6,    8,   4, UINT_MAX,                              0, UINT_MAX}, // 15 Crc     MSB
+		{   7,    8,   8, UINT_MAX,                              0, UINT_MAX}, // 16 Crs     MSB
+		{   8,    8,  12, UINT_MAX,                              0, UINT_MAX}, // 17 sqrtA   MSB
+	}, {
+		// subframe 3 entries (Table 5-10 of BDS-SIS-ICD-2.1 (November 2016), p. 34
+		// wrd shift bits msb_entry_index                    scale  eph
+		{   1,   18,  12,        9,                              1, 33      }, //  0 SOW     LSB  (seconds of BDS week least significant bits)
+		{   2,   25,   5,       10,                              8, 17      }, //  1 toe     LSB
+		{   3,   15,  15,       11, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 21      }, //  2 i0      LSB, x 2^-31 x pi
+		{   4,   19,  11,       12, -PONY_GNSS_IO_UBLOX_TWO_m31   , 18      }, //  3 Cic     LSB, x 2^-31
+		{   5,   17,  13,       13, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 24      }, //  4 Om dot  LSB, x 2^-43 x pi
+		{   6,   21,   9,       14, -PONY_GNSS_IO_UBLOX_TWO_m31   , 20      }, //  5 Cis     LSB, x 2^-31
+		{   7,   29,   1,       15, -PONY_GNSS_IO_UBLOX_TWO_m43xPI, 25      }, //  6 i dot   LSB, x 2^-43 x pi
+		{   8,   19,  11,       16, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 19      }, //  7 Om0     LSB, x 2^-31 x pi
+		{   9,    9,  21,       17, -PONY_GNSS_IO_UBLOX_TWO_m31xPI, 23      }, //  8 omega   LSB, x 2^-31 x pi
+		// extra entries for MSB sections										    
+		{   0,    4,   8, UINT_MAX,                              0, UINT_MAX}, //  9 SOW     MSB  (seconds of BDS week most significant bits)
+		{   1,    8,  10, UINT_MAX,                              0, UINT_MAX}, // 10 toe     ISB  (intermediate bits)
+		{   2,    8,  17, UINT_MAX,                              0, UINT_MAX}, // 11 i0      MSB
+		{   3,    8,   7, UINT_MAX,                              0, UINT_MAX}, // 12 Cic     MSB
+		{   4,    8,  11, UINT_MAX,                              0, UINT_MAX}, // 13 Om dot  MSB
+		{   5,    8,   9, UINT_MAX,                              0, UINT_MAX}, // 14 Cis     MSB
+		{   6,    8,  13, UINT_MAX,                              0, UINT_MAX}, // 15 i dot   MSB
+		{   7,    8,  21, UINT_MAX,                              0, UINT_MAX}, // 16 Om0     MSB
+		{   8,    8,  11, UINT_MAX,                              0, UINT_MAX}, // 17 omega   MSB
+	} };
+
+	unsigned char id;
+	unsigned short N;
+	int week0;
+	double toe;
+	pony_time_epoch epoch = {0,0,0,0,0,0}, epoch0;
+
+	// store current satellite toc, if present
+	epoch.Y = pony_gnss_io_ublox_round(sat->eph[epoch_eph+0]);
+	epoch.M = pony_gnss_io_ublox_round(sat->eph[epoch_eph+1]);
+	epoch.D = pony_gnss_io_ublox_round(sat->eph[epoch_eph+2]);
+	epoch.h = pony_gnss_io_ublox_round(sat->eph[epoch_eph+3]);
+	epoch.m = pony_gnss_io_ublox_round(sat->eph[epoch_eph+4]);
+	epoch0 = epoch;
+	if (!pony_time_epoch2gps((unsigned int *)(&week0), NULL, &epoch))
+		week0 = -1;
+	else
+		week0 -= wk_shift;
+	// store toe
+	toe = sat->eph[toe_eph];
+	// preamble
+	if ( ((subframe->dwrd[pre_word]>>pre_shift) & pre_mask) != preamble ) 
+		return 0;
+	// subframe id
+	id = (unsigned char)((subframe->dwrd[fra_word]>>fra_shift) & fra_mask);
+	// regular data processing
+	if (id < 1 || id > 3) return 0; // subframe id invalid or not supported
+	if ( !pony_gnss_io_ublox_nav_subframe_parse_data(sat->eph, subframe->dwrd, (pony_gnss_io_ublox_nav_subframe_conversion_entry *)(&(ctable[id-1])), entries_count[id-1], 1) )
+		return 0;
+	// special entries handling
+	switch (id) { 
+		case 1:
+			// URA index to user range accuracy: URA = 2^(1+N/2) [N = 0..5], 2^(N-2) [N = 6..15]
+			N = (unsigned short)(sat->eph[ ctable[0][URAI_entry].eph ]);
+			sat->eph[ ctable[0][URAI_entry].eph ] = (N < 6) ? (0x01<<(1 + N/2))*(1 + URA_sqrt2minus1*(N%2)) : (0x01<<(N-2));
+			// toc
+			if (week0 >= 0) {
+				// floor(.5+w0/wr)*wr + mod(w+wr/2,wr)-wr/2 -- closest to week0
+				week0 = pony_gnss_io_ublox_round(((double)week0)/wk_rollover)*wk_rollover + ((int)(sat->eph[ ctable[0][week_entry].eph ]) + wk_rollover/2)%wk_rollover - wk_rollover/2;
+				sat->eph[ ctable[0][week_entry].eph ] = (double)week0;
+			}
+			else
+				week0 = pony_gnss_io_ublox_round(sat->eph[ ctable[0][week_entry].eph ]);
+			// week number check
+			if (week0 <= 0)
+				return 0;
+			pony_time_gps2epoch(&epoch, (unsigned int)week0 + wk_shift, sat->eph[ ctable[0][toc_entry].eph ]);
+			sat->eph[epoch_eph+0] = epoch.Y;
+			sat->eph[epoch_eph+1] = epoch.M;
+			sat->eph[epoch_eph+2] = epoch.D;
+			sat->eph[epoch_eph+3] = epoch.h;
+			sat->eph[epoch_eph+4] = epoch.m;
+			sat->eph[epoch_eph+5] = epoch.s;
+			break;
+		case 2: 
+			// move toe most significant bits to eph_counter for further processing
+			sat->eph_counter &= ~(toe_MSB_mask<<toe_MSB_shift); // reset toe MSB bits in counter
+			sat->eph_counter |= ((unsigned long)(sat->eph[ ctable[1][toe_MSB_entry].eph ] / ctable[1][toe_MSB_entry].scale))<<toe_MSB_shift;
+			sat->eph[toe_eph] = toe;
+			break;
+		case 3: 
+			// move toe least significant bits to eph_counter for further processing
+			sat->eph_counter &= ~(toe_LSB_mask<<toe_LSB_shift); // reset toe MSB bits in counter
+			sat->eph_counter |= ((unsigned long)(sat->eph[ ctable[2][toe_LSB_entry].eph ] / ctable[2][toe_LSB_entry].scale))<<toe_LSB_shift;
+			sat->eph[toe_eph] = toe;
+			break;
+	}
+	// check whether all subframes have been collected
+	if (   epoch0.Y != pony_gnss_io_ublox_round(sat->eph[epoch_eph+0])
+		|| epoch0.M != pony_gnss_io_ublox_round(sat->eph[epoch_eph+1])
+		|| epoch0.D != pony_gnss_io_ublox_round(sat->eph[epoch_eph+2])
+		|| epoch0.h != pony_gnss_io_ublox_round(sat->eph[epoch_eph+3])
+		|| epoch0.m != pony_gnss_io_ublox_round(sat->eph[epoch_eph+4])) {// new issue of data has started
+		sat->eph_valid = 0;                    // stop using the satellite
+		sat->eph_counter &= ~eph_counter_full; // reset frame counting bits
+	}
+	sat->eph_counter |= (0x01<<(id-1));
+	if ((sat->eph_counter & eph_counter_full) == eph_counter_full) {
+		// move toe from eph_counter to ephemeris
+		sat->eph[toe_eph] = 
+			((sat->eph_counter>>toe_MSB_shift)&toe_MSB_mask)*ctable[1][toe_MSB_entry].scale +
+			((sat->eph_counter>>toe_LSB_shift)&toe_LSB_mask)*ctable[2][toe_LSB_entry].scale;
+		// set flag, reset counter
+		sat->eph_valid = 1;
+		sat->eph_counter = 0;
+	}
+
+	return 1;
+}
+
+
+
+
+// internal routines
+	// GLONASS day into 4-year cycle and tb to time epoch closest to given year, see A.3.1.3 in ICD L1,L2 GLONASS Ed. 5.1 2008, p. 57
+void pony_gnss_io_ublox_glonass_day2date(pony_time_epoch *epoch, unsigned int day) {
+
+                               // Mar Apr May Jun Jul Aug Sep Oct Nov Dec Jan
+	const unsigned short dom[] = { 30, 60, 91,121,152,183,213,244,274,305,336}; // days of year since March 1 when months end
+	
+	// GLONASSS clock starts in 1996
+	epoch->Y = (epoch->Y < 1996) ? 1996 : (epoch->Y/4)*4; // latest multiple of four not less than 1996
+
+	// year
+	if (day > 366)
+		epoch->Y += (day - 2)/365;
+	// day of year since March 1 starting from zero
+	epoch->D =  (day < 61) ? (day + 305) : (day -  61)%365;
+	// month
+	epoch->M = epoch->D/31; // exact for 340 days out of 366, less by one for the rest 26
+	if (epoch->M < 11 && epoch->D > dom[epoch->M]) // if underestimated, adjust by one
+		epoch->M++;
+	// day of year (from zero) to day of month (from one)
+	epoch->D += (epoch->M > 0) ? -dom[epoch->M-1] : 1;
+	// move starting day from March 1 to January 1
+	epoch->M += (epoch->M > 9) ? -9 : 3;
+
+}
+
+	// observation types handling
+char pony_gnss_io_ublox_obs_types_allocate(char (**obs_types)[4], size_t *obs_count, pony_gnss_sat *sat, const size_t sat_count, const pony_gnss_io_ublox_signal_id_converson_table_struct *sig) {
+
+	enum obs_type_id {code, phase, doppler, SS, obs_type_count};
+
+	const char obs_type[] = {'C','L','D','S'};
+
+	size_t i;
+
+	if (sig == NULL || obs_type == NULL || obs_count == NULL || sat == NULL)
+		return 0;
+
+	*obs_count = sig->types*obs_type_count;
+	*obs_types = (char (*)[4])calloc(*obs_count, sizeof (char [4]));
+	if (*obs_types == NULL)
+		return 0;
+
+	for (i = 0; i < *obs_count; i++) {
+		(*obs_types)[i][0] = obs_type[i%obs_type_count];
+		(*obs_types)[i][1] = sig->rnx_sig_id[i/obs_type_count][0];
+		(*obs_types)[i][2] = sig->rnx_sig_id[i/obs_type_count][1];
+	}
+
+	for (i = 0; i < sat_count; i++) {
+		sat[i].obs       = (double *)calloc(*obs_count, sizeof(double));
+		sat[i].obs_valid = (char   *)calloc(*obs_count, sizeof(char  ));
+		if (sat[i].obs == NULL || sat[i].obs_valid == NULL)
+			return 0;
+	}
+
+	return 1;
+
+}
+
+
+
+
+	// drop satellite flags
+void pony_gnss_io_ublox_drop_flags_pony_sats(pony_gnss_sat *sat, const size_t sat_count, const size_t obs_count) {
+
+	size_t i, s;
+
+	if (sat == NULL)
+		return; // nothing to do
+
+	for (s = 0; s < sat_count; s++) {
+		sat[s].t_em_valid = 0;
+		sat[s].x_valid = 0;
+		sat[s].v_valid = 0;
+		for (i = 0; i < obs_count; i++)
+			sat[s].obs_valid[i] = 0;
+	}
+
+}
+
+
+
+
+	// drop solution flags
+void pony_gnss_io_ublox_drop_flags_pony_sol(pony_sol *sol) {
+
+	sol->x_valid	= 0;
+	sol->llh_valid	= 0;
+	sol->v_valid	= 0;
+	sol->q_valid	= 0;
+	sol->L_valid	= 0;
+	sol->rpy_valid	= 0;
+	sol->dt_valid	= 0;
+
+}
+
+
+
+	// uBlox 8-bit Fletcher recursive checksum
+void pony_gnss_io_ublox_checksum_recurse(unsigned char *cs,  unsigned char byte) {
+		cs[0] = 0xff & ( (0xff & (cs[0])) + (0xff & byte ) );
+		cs[1] = 0xff & ( (0xff & (cs[1])) + (0xff & cs[0]) );
+}
+
+
+
+
+	// free memory with pointer NULL-check and NULL-assignment
+void pony_gnss_io_ublox_free_null(void **ptr) 
+{
+	if (*ptr == NULL)
+		return;
+	free(*ptr);
+	*ptr = NULL;
+}
+
+
+
+
+	// round to the nearest integer
+int pony_gnss_io_ublox_round(double x) {
+	return ( (int)( x >= 0.0 ? (x + 0.5) : (x - 0.5) ) );
+}
+
+	// remainder after division for doubles
+double pony_gnss_io_ublox_dmod(double x, double y) {
+    return x - (int)(x/y) * y;
+}

--- a/gnss/io/pony_gnss_io_ublox.h
+++ b/gnss/io/pony_gnss_io_ublox.h
@@ -1,0 +1,7 @@
+// Aug-2020
+//
+/*	pony_gnss_io_rinex 
+	
+	pony plugins for GNSS u-Blox receiver input/output:
+*/
+void pony_gnss_io_ublox_read_file(void); // reads observation and navigation data (measurements and ephemeris) from u-Blox binary files, protocol version 6, 8, 9

--- a/gnss/pony_gnss_sat.c
+++ b/gnss/pony_gnss_sat.c
@@ -1,0 +1,2018 @@
+// Aug-2020
+//
+/*	pony_gnss_sat 
+	
+	pony plugins for GNSS satellite-related calculations:
+
+	- pony_gnss_sat_pos_vel_clock_gps
+		Calculates position, velocity and clock correction for all GPS     satellites with valid ephemeris.
+	- pony_gnss_sat_pos_vel_clock_glo
+		Calculates position, velocity and clock correction for all GLONASS satellites with valid ephemeris.
+	- pony_gnss_sat_pos_vel_clock_gal
+		Calculates position, velocity and clock correction for all Galileo satellites with valid ephemeris.
+	- pony_gnss_sat_pos_vel_clock_bds 
+		Calculates position, velocity and clock correction for all BeiDou  satellites with valid ephemeris.
+*/
+
+#include <stdlib.h>
+#include <math.h>
+
+#include "../pony.h"
+
+// pony bus version check
+#define PONY_GNSS_SAT_BUS_VERSION_REQUIRED 7
+#if PONY_BUS_VERSION < PONY_GNSS_SAT_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+// internal routines
+	// single-receiver satellite calculations for GPS
+void   pony_gnss_sat_pos_vel_clock_gps_single_receiver(pony_gnss *gnss, double *allIODE, double *allA, double *alln, double *allE, double **allaf);
+	// single-receiver satellite calculations for GLONASS
+void   pony_gnss_sat_pos_vel_clock_glo_single_receiver(pony_gnss *gnss,  double *t, double **x, double **v, double **a, int *tb,  double *rk4_y, double **rk4_k);
+void   pony_gnss_sat_glo_motion_rk4_step(double *x, double *v, double *a,  double dt,  double *rk4_y, double **rk4_k);
+void   pony_gnss_sat_glo_motion_ode_fun(double *dy,  double *y, double *a);
+	// single-receiver satellite calculations for Galileo
+void   pony_gnss_sat_pos_vel_clock_gal_single_receiver(pony_gnss *gnss, double *allIODnav, double *allA, double *alln, double *allE, double **allaf);
+	// single-receiver satellite calculations for BeiDou
+void   pony_gnss_sat_pos_vel_clock_bds_single_receiver(pony_gnss *gnss, double *allSOW, double *allA, double *alln, double *allE, double **alla);
+	// service routines
+char   pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gps  (double  ***ptr);                             // allocate memory for [gnss_count x sat_count                ] doubles
+char   pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_gps (double ****ptr, const size_t internal_size); // allocate memory for [gnss_count x sat_count x internal_size] doubles
+char   pony_gnss_sat_alloc_dppointer_gnss_count_sat_count_glo (double  ***ptr);                             // allocate memory for [gnss_count x sat_count                ] doubles
+char   pony_gnss_sat_alloc_ippointer_gnss_count_sat_count_glo (int     ***ptr);                             // allocate memory for [gnss_count x sat_count                ] integers
+char   pony_gnss_sat_alloc_dpppointer_gnss_count_sat_count_glo(double ****ptr, const size_t internal_size); // allocate memory for [gnss_count x sat_count x internal_size] doubles
+char   pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gal  (double  ***ptr);                             // allocate memory for [gnss_count x sat_count                ] doubles
+char   pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_gal (double ****ptr, const size_t internal_size); // allocate memory for [gnss_count x sat_count x internal_size] doubles
+char   pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_bds  (double  ***ptr);                             // allocate memory for [gnss_count x sat_count                ] doubles
+char   pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_bds (double ****ptr, const size_t internal_size); // allocate memory for [gnss_count x sat_count x internal_size] doubles
+void   pony_gnss_sat_free_pppointer_gnss_count_sat_count_gps  (void   ****ptr);                             // free memory and assign NULL to pointer to [gnss_count x sat_count] double arrays 
+void   pony_gnss_sat_free_pppointer_gnss_count_sat_count_glo  (void   ****ptr);                             // free memory and assign NULL to pointer to [gnss_count x sat_count] double arrays
+void   pony_gnss_sat_free_pppointer_gnss_count_sat_count_gal  (void   ****ptr);                             // free memory and assign NULL to pointer to [gnss_count x sat_count] double arrays
+void   pony_gnss_sat_free_pppointer_gnss_count_sat_count_bds  (void   ****ptr);                             // free memory and assign NULL to pointer to [gnss_count x sat_count] double arrays
+void   pony_gnss_sat_free_ppointer_gnss_count                 (void    ***ptr);                             // free memory and assign NULL to pointer to  gnss_count              double arrays
+double pony_gnss_sat_epoch_diff_within_day(pony_time_epoch *t1, pony_time_epoch *t2);                       // difference between epochs within 24 hours
+int    pony_gnss_sat_round(double x);                                                                       // round to the nearest integer
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// plugin definitions
+
+/* pony_gnss_sat_pos_vel_clock_gps - pony plugin
+	
+	Calculates position, velocity and clock correction for all GPS satellites with valid ephemeris. 
+
+	description:
+		- ephemeris have to match RINEX format and order;
+		- calculations comply with Sections 20.3.3.3.3 and 20.3.3.4.3 of IS-GPS-200J (22 May 2018);
+		- if no single code measurement available, the calculated position refers to 
+		  receiver reference epoch (pony->gnss[].epoch) in ECEF at the same time instant;
+		- if at least one code measurement available, the calculated position refers to 
+		  estimated time of signal emission (pony->gnss[].gps.sat[].t_em) in ECEF at estimated time of signal reception;
+        - if receiver position-and-clock solution is available (pony->gnss[].sol.x_valid, pony->gnss[].sol.dt_valid), 
+		  ECEF frame is adjusted by receiver clock error, and satellite elevation (pony->gnss[].gps.sat[s].sinEl) becomes available;
+		- all time intervals only less than 24 hours;
+		- satellite position fit intervals only less than 6 hours.
+	uses:
+		pony->gnss_count
+		pony->gnss[].epoch
+		pony->gnss[].sol. x
+		pony->gnss[].sol. x_valid
+		pony->gnss[].sol.dt
+		pony->gnss[].sol.dt_valid
+		pony->gnss[].gps->max_sat_count
+		pony->gnss[].gps->    obs_count
+		pony->gnss[].gps->    obs_types
+		pony->gnss[].gps->sat[].eph
+		pony->gnss[].gps->sat[].eph_valid
+		pony->gnss[].gps->sat[].obs_valid
+		pony->gnss[].gps->sat[].  x_valid
+	changes:
+		pony->gnss[].gps->sat[]. t_em
+		pony->gnss[].gps->sat[]. t_em_valid	
+		pony->gnss[].gps->sat[].    x
+		pony->gnss[].gps->sat[].    x_valid
+		pony->gnss[].gps->sat[].    v
+		pony->gnss[].gps->sat[].    v_valid
+		pony->gnss[].gps->sat[].Deltatsv
+		pony->gnss[].gps->sat[].sinEl
+		pony->gnss[].gps->sat[].sinEl_valid
+		pony->gnss[].gps->sat[].  eph_valid	
+	cfg parameters:
+		none
+*/
+void pony_gnss_sat_pos_vel_clock_gps(void) {
+
+	static double **allIODE = NULL; // issues of data, ephemeris, for each receiver and each satellite to check if they have changed
+	// elements pre-calculated and constant between ephemeride issues to speed up epoch processing
+	static double **allA = NULL, **alln = NULL, **allE = NULL, ***allaf = NULL;
+
+	size_t r, s;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0) {
+
+		// allocate memory
+		if (   !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gps (&allIODE)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gps (&allA)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gps (&alln)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gps (&allE)
+			|| !pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_gps(&allaf,3)
+			) {
+			pony->mode = -1;
+			return;
+		}
+		// initialize non-zeros
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].gps == NULL) // do nothing if no gps data in the receiver available
+				continue;
+			for (s = 0; s < pony->gnss[r].gps->max_sat_count; s++) {
+				allIODE	[r][s] = -1;	
+				allE	[r][s] = -20;
+			}
+		}
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allIODE) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allA   ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&alln   ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allE   ) );
+		pony_gnss_sat_free_pppointer_gnss_count_sat_count_gps( (void ****)(&allaf  ) );
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+		
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].gps == NULL) // do nothing if no gps structure initialized in this receiver
+				continue;
+			// process single receiver
+			pony_gnss_sat_pos_vel_clock_gps_single_receiver(&(pony->gnss[r]), allIODE[r], allA[r], alln[r], allE[r], allaf[r]);
+		}
+
+	}
+
+}
+
+/* pony_gnss_sat_pos_vel_clock_glo - pony plugin
+	
+	Calculates position, velocity and clock correction for all GLONASS satellites with valid ephemeris. 
+
+	description:
+		- ephemeris have to match RINEX format and order;
+		- calculations comply with Section A3.1.2 of ICD GLONASS Edition 5.1 2008;
+		- if no single code measurement available, the calculated position refers to 
+		  receiver reference epoch (pony->gnss[].epoch) in ECEF at the same time instant;
+		- if at least one code measurement available, the calculated position refers to 
+		  estimated time of signal emission (pony->gnss[].glo.sat[].t_em) in ECEF at estimated time of signal reception;
+        - if receiver position-and-clock solution is available (pony->gnss[].sol.x_valid, pony->gnss[].sol.dt_valid), 
+		  ECEF frame is adjusted by receiver clock error, and satellite elevation (pony->gnss[].glo.sat[s].sinEl) becomes available;
+		- all time intervals only less than 24 hours;
+		- satellite position fit intervals only less than 6 hours.
+	uses:
+		pony->gnss_count
+		pony->gnss[].epoch
+		pony->gnss[].sol. x
+		pony->gnss[].sol. x_valid
+		pony->gnss[].sol.dt
+		pony->gnss[].sol.dt_valid
+		pony->gnss[].glo->max_sat_count
+		pony->gnss[].glo->    obs_count
+		pony->gnss[].glo->    obs_types
+		pony->gnss[].glo->clock_corr
+		pony->gnss[].glo->clock_corr_to
+		pony->gnss[].glo->clock_corr_valid
+		pony->gnss[].glo->sat[].eph
+		pony->gnss[].glo->sat[].eph_valid
+		pony->gnss[].glo->sat[].obs_valid
+		pony->gnss[].glo->sat[].  x_valid
+	changes:
+		pony->gnss[].glo->sat[]. t_em
+		pony->gnss[].glo->sat[]. t_em_valid	
+		pony->gnss[].glo->sat[].    x
+		pony->gnss[].glo->sat[].    x_valid
+		pony->gnss[].glo->sat[].    v
+		pony->gnss[].glo->sat[].    v_valid
+		pony->gnss[].glo->sat[].Deltatsv
+		pony->gnss[].glo->sat[].sinEl
+		pony->gnss[].glo->sat[].sinEl_valid
+		pony->gnss[].glo->sat[].  eph_valid	
+	cfg parameters:
+		none
+*/
+void pony_gnss_sat_pos_vel_clock_glo(void) {
+
+	const int rk4_state = 6, rk4_coeff = 4;
+	static double 
+		**t ,			// at times t (sec) within a day [0 86400], for each receiver and each satellite:
+		***x,			// last known positions X, Y, Z (m),
+		***v,			// last known velocity components Vx, Vy, Vz (m/s),
+		***a;			// last known extra acceleration components (m/s^2);
+	static int **tb;	// toc of the ephemeris used (sec) within a day [0 86400]
+	static double *rk4_y, **rk4_k; // memory array to be used in Runge-Kutta integration
+
+	size_t r, s;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0) {
+
+		// allocate memory
+		rk4_y = (double * )calloc( rk4_state, sizeof(double  ) );
+		rk4_k = (double **)calloc( rk4_coeff, sizeof(double *) );
+		if ( rk4_y == NULL || rk4_k == NULL
+			|| !pony_gnss_sat_alloc_dppointer_gnss_count_sat_count_glo (&t   )
+			|| !pony_gnss_sat_alloc_dpppointer_gnss_count_sat_count_glo(&x ,3)
+			|| !pony_gnss_sat_alloc_dpppointer_gnss_count_sat_count_glo(&v ,3)
+			|| !pony_gnss_sat_alloc_dpppointer_gnss_count_sat_count_glo(&a, 3)
+			|| !pony_gnss_sat_alloc_ippointer_gnss_count_sat_count_glo (&tb  ) ) {
+			pony->mode = -1;
+			return;
+		}
+		for (r = 0; r < rk4_coeff; r++) {
+			rk4_k[r] = (double *)calloc( rk4_state, sizeof(double) );
+			if (rk4_k[r] == NULL) {
+				pony->mode = -1;
+				return;
+			}
+		}
+		// init tb with -1 - undefined seconds of the day
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].glo != NULL)
+				for (s = 0; s < pony->gnss[r].glo->max_sat_count; s++)
+					tb[r][s] = -1;
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void *** )(&t ) ); 
+		pony_gnss_sat_free_pppointer_gnss_count_sat_count_glo( (void ****)(&x ) );
+		pony_gnss_sat_free_pppointer_gnss_count_sat_count_glo( (void ****)(&v ) );
+		pony_gnss_sat_free_pppointer_gnss_count_sat_count_glo( (void ****)(&a ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void *** )(&tb) );
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+		
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].glo == NULL) // do nothing if no glonass data initialized in this receiver
+				continue;
+			// process single receiver
+			pony_gnss_sat_pos_vel_clock_glo_single_receiver(&(pony->gnss[r]),   t[r], x[r], v[r], a[r], tb[r],  rk4_y, rk4_k);
+		}
+
+	}
+
+}
+
+/* pony_gnss_sat_pos_vel_clock_gal - pony plugin
+	
+	Calculates position, velocity and clock correction for all Galileo satellites with valid ephemeris. 
+
+	description:
+		- ephemeris have to match RINEX format and order;
+		- calculations comply with Sections 5.1.1 and 5.1.4 of Galileo OS SIS ICD Issue 1.2 (November 2015);
+		- if no single code measurement available, the calculated position refers to 
+		  receiver reference epoch (pony->gnss[].epoch) in ECEF at the same time instant;
+		- if at least one code measurement available, the calculated position refers to 
+		  estimated time of signal emission (pony->gnss[].glo.sat[].t_em) in ECEF at estimated time of signal reception;
+        - if receiver position-and-clock solution is available (pony->gnss[].sol.x_valid, pony->gnss[].sol.dt_valid), 
+		  ECEF frame is adjusted by receiver clock error, and satellite elevation (pony->gnss[].glo.sat[s].sinEl) becomes available;
+		- all time intervals only less than 24 hours;
+		- satellite position fit intervals only less than 6 hours.
+	uses:
+		pony->gnss_count
+		pony->gnss[].epoch
+		pony->gnss[].sol. x
+		pony->gnss[].sol. x_valid
+		pony->gnss[].sol.dt
+		pony->gnss[].sol.dt_valid
+		pony->gnss[].gal->max_sat_count
+		pony->gnss[].gal->    obs_count
+		pony->gnss[].gal->    obs_types
+		pony->gnss[].gal->sat[].eph
+		pony->gnss[].gal->sat[].eph_valid
+		pony->gnss[].gal->sat[].obs_valid
+		pony->gnss[].gal->sat[].  x_valid
+	changes:
+		pony->gnss[].gal->sat[]. t_em
+		pony->gnss[].gal->sat[]. t_em_valid	
+		pony->gnss[].gal->sat[].    x
+		pony->gnss[].gal->sat[].    x_valid
+		pony->gnss[].gal->sat[].    v
+		pony->gnss[].gal->sat[].    v_valid
+		pony->gnss[].gal->sat[].Deltatsv
+		pony->gnss[].gal->sat[].sinEl
+		pony->gnss[].gal->sat[].sinEl_valid
+		pony->gnss[].gal->sat[].  eph_valid	
+	cfg parameters:
+		none
+*/
+void pony_gnss_sat_pos_vel_clock_gal(void) {
+
+	static double **allIODnav = NULL; // issues of data, ephemeris, for each receiver and each satellite to check if they have changed
+	// elements pre-calculated and constant between ephemeride issues to speed up epoch processing
+	static double **allA = NULL, **alln = NULL, **allE = NULL, ***allaf = NULL;
+
+	size_t r, s;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0) {
+
+		// allocate memory
+		if (   !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gal (&allIODnav)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gal (&allA     )
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gal (&alln     )
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gal (&allE     )
+			|| !pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_gal(&allaf, 3 )
+			) {
+			pony->mode = -1;
+			return;
+		}
+		// initialize non-zeros
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].gal == NULL) // do nothing if no galileo data in the receiver available
+				continue;
+			for (s = 0; s < pony->gnss[r].gal->max_sat_count; s++) {
+				allIODnav	[r][s] = -1;	
+				allE		[r][s] = -20;
+			}
+		}
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allIODnav) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allA     ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&alln     ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allE     ) );
+		pony_gnss_sat_free_pppointer_gnss_count_sat_count_gal( (void ****)(&allaf    ) );
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+		
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].gal == NULL) // do nothing if no galileo structure initialized in this receiver
+				continue;
+			// process single receiver
+			pony_gnss_sat_pos_vel_clock_gal_single_receiver(&(pony->gnss[r]), allIODnav[r], allA[r], alln[r], allE[r], allaf[r]);
+		}
+
+	}
+
+}
+
+/* pony_gnss_sat_pos_vel_clock_bds - pony plugin
+	
+	Calculates position, velocity and clock correction for all BeiDou satellites with valid ephemeris. 
+
+	description:
+		- ephemeris have to match RINEX format and order;
+		- calculations comply with Sections 5.2.4.10 and 5.2.4.12 of BeiDou SIS ICD OSS Version 2.1 (November 2016);
+		- if no single code measurement available, the calculated position refers to 
+		  receiver reference epoch (pony->gnss[].epoch) in ECEF at the same time instant;
+		- if at least one code measurement available, the calculated position refers to 
+		  estimated time of signal emission (pony->gnss[].glo.sat[].t_em) in ECEF at estimated time of signal reception;
+        - if receiver position-and-clock solution is available (pony->gnss[].sol.x_valid, pony->gnss[].sol.dt_valid), 
+		  ECEF frame is adjusted by receiver clock error, and satellite elevation (pony->gnss[].glo.sat[s].sinEl) becomes available;
+		- all time intervals only less than 24 hours;
+		- satellite position fit intervals only less than 6 hours.
+	uses:
+		pony->gnss_count
+		pony->gnss[].epoch
+		pony->gnss[].sol. x
+		pony->gnss[].sol. x_valid
+		pony->gnss[].sol.dt
+		pony->gnss[].sol.dt_valid
+		pony->gnss[].bds->max_sat_count
+		pony->gnss[].bds->    obs_count
+		pony->gnss[].bds->    obs_types
+		pony->gnss[].bds->sat[].eph
+		pony->gnss[].bds->sat[].eph_valid
+		pony->gnss[].bds->sat[].obs_valid
+		pony->gnss[].bds->sat[].  x_valid
+	changes:
+		pony->gnss[].bds->sat[]. t_em
+		pony->gnss[].bds->sat[]. t_em_valid	
+		pony->gnss[].bds->sat[].    x
+		pony->gnss[].bds->sat[].    x_valid
+		pony->gnss[].bds->sat[].    v
+		pony->gnss[].bds->sat[].    v_valid
+		pony->gnss[].bds->sat[].Deltatsv
+		pony->gnss[].bds->sat[].sinEl
+		pony->gnss[].bds->sat[].sinEl_valid
+		pony->gnss[].bds->sat[].  eph_valid	
+	cfg parameters:
+		none
+*/
+void pony_gnss_sat_pos_vel_clock_bds(void) {
+
+	static double **allSOW = NULL; // seconds of the week of the NAV message, for each receiver and each satellite to check if they have changed
+	// elements pre-calculated and constant between ephemeride issues to speed up epoch processing
+	static double **allA = NULL, **alln = NULL, **allE = NULL, ***alla = NULL;
+
+	size_t r, s;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0) {
+
+		// allocate memory
+		if (   !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_bds (&allSOW)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_bds (&allA)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_bds (&alln)
+			|| !pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_bds (&allE)
+			|| !pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_bds(&alla,3)
+			) {
+			pony->mode = -1;
+			return;
+		}
+		// initialize non-zeros
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].bds == NULL) // do nothing if no beidou data in the receiver available
+				continue;
+			for (s = 0; s < pony->gnss[r].bds->max_sat_count; s++) {
+				allSOW	[r][s] = -1;	
+				allE	[r][s] = -20;
+			}
+		}
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allSOW) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allA  ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&alln  ) );
+		pony_gnss_sat_free_ppointer_gnss_count               ( (void  ***)(&allE  ) );
+		pony_gnss_sat_free_pppointer_gnss_count_sat_count_bds( (void ****)(&alla  ) );
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+		
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].bds == NULL) // do nothing if no beidou structure initialized in this receiver
+				continue;
+			// process single receiver
+			pony_gnss_sat_pos_vel_clock_bds_single_receiver(&(pony->gnss[r]), allSOW[r], allA[r], alln[r], allE[r], alla[r]);
+		}
+
+	}
+
+}
+
+
+
+
+
+
+
+
+// internal routines
+	// single-receiver satellite calculations for GPS
+void pony_gnss_sat_pos_vel_clock_gps_single_receiver(pony_gnss *gnss, double *allIODE, double *allA, double *alln, double *allE, double **allaf)
+{
+	const char   code_id          = 'C';
+	const double 
+		max_fit_interval          = 6*3600,           // maximum fit interval, seconds
+		anomaly_precision         = 1.0/0xe000000000, // radians, roughly 1e-12
+		orbit_radius_squared_min  = 676e12,           //  m^2
+		orbit_radius_squared_max  = 784e12,           //  m^2
+		orbital_speed_squared_min = 1.4e7,            // (m/s)^2
+		orbital_speed_squared_max = 1.6e7;            // (m/s)^2
+	const int max_iterations      = 32;
+
+	// ephemeris as in Table 20-I of IS-GPS-200J (22 May 2018) p. 95
+	// (!) toc fit intervals only less than 24 hours supported yet
+	// (!) toc expressed as pony_time_epoch: Year, Month, Day, hours, minutes, seconds
+	int CL2, week, L2Pflag, SVa, SVh, IODC;
+	pony_time_epoch toc;
+	double TGD, af2, af1, af0;
+
+	// subframe 1 parameters as in Section 20.3.3.3.3 of IS-GPS-200J (22 May 2018) p. 95
+	double t_toc, Deltatr; // Deltatsv
+
+	// ephemeris as in Table 20-III of IS-GPS-200J (22 May 2018) p. 103, 
+	// (!) Deltan, Omdot, idot - in rad/s, according to RINEX
+	// (!) M0, Om0, i0, om - in radiands, according to RINEX
+	// (!) toe is seconds of GPS week, a fractional part to go with week number, according to RINEX
+	double IODE, Crs, Deltan, M0, Cuc, e, Cus, sqrtA, toe, Cic, Om0, Cis, i0, Crc, om, Omdot, idot;
+
+	// elements of coordinate systems as in Table 20-IV of IS-GPS-200J (22 May 2018) p. 104, except for pre-calculated ones
+	double // A, 
+		n0, // t, 
+		tk, // n, 
+		Mk, Ek, nuk, Phik, duk, drk, dik, uk, rk, ik, xk_, yk_, Omk, xk, yk, zk;
+
+	// their derivatives for velocity calculation
+	double
+		nuk_dot, duk_dot, drk_dot, dik_dot;
+
+	size_t i, s;
+	double sqrt1e2, sinE, one_ecosE, cos2Phik, sin2Phik, cuk, suk, cOmk, sOmk, cik, sik, r, dx, ut, cut, sut, vr, vu, v0[3], v[3];
+	pony_gnss_sat *sat; // current satellite
+
+	// requires gnss, gps and sat structure to be initialized
+	if (gnss == NULL || gnss->gps == NULL || gnss->gps->sat == NULL)
+		return;
+
+	// run through all gps satellites
+	for (s = 0; s < gnss->gps->max_sat_count; s++) 
+	{
+		sat = &(gnss->gps->sat[s]);
+		if (!sat->eph_valid || sat->eph == NULL) // do nothing if no valid ephemeris available
+			continue;
+
+		// ephemeris 0 -- 5  - toc (see RINEX documentation)
+		toc.Y	= pony_gnss_sat_round(sat->eph[0]);
+		toc.M	= pony_gnss_sat_round(sat->eph[1]);
+		toc.D	= pony_gnss_sat_round(sat->eph[2]);
+		toc.h	= pony_gnss_sat_round(sat->eph[3]);
+		toc.m	= pony_gnss_sat_round(sat->eph[4]);
+		toc.s	=                     sat->eph[5] ;
+
+		// check fit interval
+		// t - toc, time elapsed since the time of clock
+		// (!) intervals only less than 24 hours are supported
+		t_toc = pony_gnss_sat_epoch_diff_within_day( &(gnss->epoch), &(toc) );
+		if (fabs(t_toc) >= max_fit_interval)
+				continue;
+
+		// all other ephemeris (see RINEX documentation & GPS interface specifications)
+		af0		=                     sat->eph[ 6] ;
+		af1		=                     sat->eph[ 7] ;
+		af2		=                     sat->eph[ 8] ;
+		IODE	=                     sat->eph[ 9] ;
+		Crs		=                     sat->eph[10] ;
+		Deltan	=                     sat->eph[11] ;
+		M0		=                     sat->eph[12] ;
+		Cuc		=                     sat->eph[13] ;
+		e		=                     sat->eph[14] ;
+		Cus		=                     sat->eph[15] ;
+		sqrtA	=                     sat->eph[16] ;
+		toe		=                     sat->eph[17] ;
+		Cic		=                     sat->eph[18] ;
+		Om0		=                     sat->eph[19] ;
+		Cis		=                     sat->eph[20] ;
+		i0		=                     sat->eph[21] ;
+		Crc		=                     sat->eph[22] ;
+		om		=                     sat->eph[23] ;
+		Omdot	=                     sat->eph[24] ;
+		idot	=                     sat->eph[25] ;
+		CL2		= pony_gnss_sat_round(sat->eph[26]); // Codes on L2 channel, skip this field, not analyzed yet
+		week	= pony_gnss_sat_round(sat->eph[27]);
+		L2Pflag	= pony_gnss_sat_round(sat->eph[28]); // L2 P data flag, skip this field, not analyzed yet
+		SVa		= pony_gnss_sat_round(sat->eph[29]); // SV accuracy, skip this field, not analyzed yet
+		SVh	    = pony_gnss_sat_round(sat->eph[30]); // SV health
+		TGD		=                     sat->eph[31] ;
+		IODC	= pony_gnss_sat_round(sat->eph[32]);
+
+		if (SVh) {
+				// drop all flags and skip calculations if SV is not OK
+				sat->eph_valid		= 0;
+				sat->t_em_valid		= 0;
+				sat->x_valid		= 0;
+				sat->v_valid		= 0;
+				sat->sinEl_valid	= 0;
+				continue;
+		}
+		// recalculate stored quantities if new issue of data detected
+		if ( pony_gnss_sat_round(IODE) != pony_gnss_sat_round(allIODE[s]) ) {
+			allIODE[s] = IODE;
+			// quantities that are constant between issues of ephemeris
+			allA [s]	= sqrtA*sqrtA;
+			n0			= sqrt(pony->gnss_const.gps.mu)/(sqrtA*sqrtA*sqrtA);
+			alln [s]	= n0 + Deltan;
+			allaf[s][0]	= af0;
+			allaf[s][1]	= af1;
+			allaf[s][2]	= af2;
+		}
+		
+		// t_em - time of emission 
+		// (!) fit intervals only less than 12 hours are supported yet
+			// toe - time of epoch treated as t_em base approximation
+		sat->t_em = gnss->epoch.h*3600.0 + gnss->epoch.m*60.0 + gnss->epoch.s;
+			// look for any valid code measurement to compensate for travel time
+		ut = 0; // ECEF frame rotation angle
+		for (i = 0; i < gnss->gps->obs_count; i++)
+			if (gnss->gps->obs_types[i][0] == code_id && sat->obs_valid[i]) {
+				ut = sat->obs[i]/pony->gnss_const.c; // base estimate for travel time
+				if (sat->x_valid) // if position is already available, satellite clock correction applies
+					ut += sat->Deltatsv;
+				sat->t_em -= ut; // estimate for the time of emission in the system time frame
+				sat->t_em_valid = 1;
+
+				if (gnss->sol.dt_valid) // if receiver clock error estimated, receiver clock correction applies
+					ut -= gnss->sol.dt;				
+				ut *= pony->gnss_const.gps.u; // ECEF frame rotation angle between emission and reception
+				break;
+			}
+	
+
+		// satellite position
+		// (!) fit intervals only less than 12 hours are supported yet
+
+			// tk - time from ephemeris reference epoch
+		tk = sat->t_em - fmod(toe, pony->gnss_const.sec_in_d);
+		if (tk < -pony->gnss_const.sec_in_d/2) // day rollover - forward
+			tk += pony->gnss_const.sec_in_d;
+		if (tk >  pony->gnss_const.sec_in_d/2) // day rollover - backward
+			tk -= pony->gnss_const.sec_in_d;
+
+			// Mk - mean anomaly at current time
+		Mk = M0 + alln[s]*tk; 
+
+			// Kepler equation by iterations
+		if (allE[s] < -10) // if no previous estimate available, take the mean motion
+			allE[s] = Mk;
+		i = 0;
+		do {	
+			Ek = allE[s];
+			allE[s] = Mk + e*sin(Ek);
+			i++;
+		} while (fabs(Ek - allE[s]) > anomaly_precision && i < max_iterations);
+
+			// nuk - true anomaly
+		sqrt1e2 = sqrt(1-e*e);
+		sinE = sin(Ek);
+		nuk = atan2( sqrt1e2*sinE, cos(Ek)-e );
+			// Phik - argument of latitude at current time
+		Phik = nuk + om;
+			// second harmonic perturbations
+		cos2Phik = cos(2*Phik); sin2Phik = sin(2*Phik);
+		duk = Cus*sin2Phik + Cuc*cos2Phik; // duk - argument of latitude correction
+		drk = Crs*sin2Phik + Crc*cos2Phik; // drk - radius correction
+		dik = Cis*sin2Phik + Cic*cos2Phik; // dik - inclination correction
+			// corrected argument of latitude
+		uk = Phik + duk;
+			// corrected radius
+		one_ecosE = 1 - e*cos(Ek);
+		rk = allA[s]*one_ecosE + drk;
+			// corrected inclination
+		ik = i0 + dik + idot*tk;
+			// position in orbital plane
+		cuk = cos(uk); suk = sin(uk);
+		xk_ = rk*cuk;
+		yk_ = rk*suk;
+			// corrected longitude of ascending node
+		Omk = Om0 + (Omdot - pony->gnss_const.gps.u)*tk - pony->gnss_const.gps.u*toe; // gnss->gps_const.u stands for Omedot
+		
+			// Earth-fixed coordinates
+		cOmk = cos(Omk); sOmk = sin(Omk); 
+		cik = cos(ik); sik = sin(ik);
+		xk = xk_*cOmk - yk_*cik*sOmk;
+		yk = xk_*sOmk + yk_*cik*cOmk;
+		zk = yk_*sik;
+
+		// radius to be checked
+		r = xk*xk + yk*yk + zk*zk;
+
+		// rotate the coordinate frame to the time of reception if t_em was corrected
+		cut = cos(ut); 
+		sut = sin(ut);
+		sat->x[0] =  xk*cut + yk*sut;
+		sat->x[1] = -xk*sut + yk*cut;
+		sat->x[2] =  zk;
+		if (orbit_radius_squared_min < r && r < orbit_radius_squared_max)
+			sat->x_valid = 1;
+
+		// SV clock correction as in 20.3.3.3.3.1 of IS-GPS-200J (22 May 2018), p. 96
+		// (!) fit intervals only less than 12 hours are supported yet
+			// t_toc = t - t0c is calculated above
+			// relativistic correction
+		Deltatr = pony->gnss_const.gps.F*e*sqrtA*sinE;
+			// SV PRN code phase time offset
+		sat->Deltatsv = allaf[s][0] + allaf[s][1]*t_toc + allaf[s][2]*t_toc*t_toc + Deltatr;
+
+		// check if position is available to calculate elevation
+		if (sat->x_valid && gnss->sol.x_valid) {
+			for (i = 0, r = 0.0, sat->sinEl = 0; i < 3; i++) {
+				dx = sat->x[i] - gnss->sol.x[i];
+				sat->sinEl += gnss->sol.x[i]*dx;
+				r += dx*dx;
+			}
+			r = sqrt(r);
+			sat->sinEl /= r;
+
+			for (i = 0, r = 0.0; i < 3; i++)
+				r += gnss->sol.x[i]*gnss->sol.x[i];
+			r = sqrt(r);
+			sat->sinEl /= r;
+			sat->sinEl_valid = 1;
+		}
+		else
+			sat->sinEl_valid = 0;
+
+		// velocity calculation
+			// derivatives
+		nuk_dot = alln[s]*sqrt1e2/(one_ecosE*one_ecosE);
+		duk_dot = 2*(Cus*cos2Phik - Cuc*sin2Phik)*nuk_dot;
+		drk_dot = 2*(Crs*cos2Phik - Crc*sin2Phik)*nuk_dot;
+		dik_dot = 2*(Cis*cos2Phik - Cic*sin2Phik)*nuk_dot;
+			// absolute velocity components in orbital plane
+		vr = allA[s]*alln[s]*e*sinE/one_ecosE + drk_dot;
+		vu = rk*(nuk_dot + duk_dot);
+		v0[0] =	vr*cuk - vu*suk;
+		v0[1] = vr*suk + vu*cuk;
+		v0[2] = rk*sin(nuk)*(idot + dik_dot);
+			// absolute velocity components in ECEF
+		v[0] = v0[0]*cOmk -		v0[1]*cik*sOmk +	v0[2]*sik*sOmk;
+		v[1] = v0[0]*sOmk +		v0[1]*cik*cOmk -	v0[2]*sik*cOmk;
+		v[2] =					v0[1]*sik +			v0[2]*cik;
+			// speed to be checked
+		r = v[0]*v[0] + v[1]*v[1] + v[2]*v[2];
+			// relative to ECEF velocity components
+		sat->v[0] = v[0] + (pony->gnss_const.gps.u - Omdot)*sat->x[1];
+		sat->v[1] = v[1] - (pony->gnss_const.gps.u - Omdot)*sat->x[0];
+		sat->v[2] = v[2];
+
+		if (orbital_speed_squared_min < r && r < orbital_speed_squared_max)
+			sat->v_valid = 1;
+		else
+			sat->v_valid = 0;
+	}
+
+}
+
+	// single-receiver satellite calculations for GLONASS
+void pony_gnss_sat_pos_vel_clock_glo_single_receiver(pony_gnss *gnss,  double *t, double **x, double **v, double **a, int *tb,  double *rk4_y, double **rk4_k) {
+
+	const char code_id = 'C', utc_time_id[] = "UT";
+	const double 
+		max_dt           = 1,              // maximum integration step size, sec
+		max_fit_interval = 6*3600,         // maximum fit interval, seconds
+		orbit_radius_squared_min = 625e12, //  m^2
+		orbit_radius_squared_max = 676e12, //  m^2
+		orbital_speed_squared_max = 3.6e7; // (m/s)^2
+
+	// ephemeris as in Table 4.5 of ICD GLONASS Edition 5.1 2008
+	double gamma_n, tau_n;	// clock correction parameters
+	int l_n;				// satellite health
+	// almanac data as in Table 4.9 of ICD GLONASS Edition 5.1 2008
+	double tau_c;
+
+	// (!) toc fit intervals only less than 24 hours supported yet
+	// (!) toc expressed as pony_time_epoch: Year, Month, Day, hours, minutes, seconds
+	pony_time_epoch toc;
+	pony_gnss_sat *sat;
+	double tem_tb, tem_t, dt;
+	double r, dx, vel, ut, cut, sut;
+	int tb_new;
+	size_t i, k, s;
+
+	// requires gnss, glo and sat structure to be initialized
+	if (gnss == NULL || gnss->glo == NULL || gnss->glo->sat == NULL)
+		return;
+
+	// run through all glonass satellites
+	for (s = 0; s < gnss->glo->max_sat_count; s++) {
+		sat = &(gnss->glo->sat[s]);
+		if (!sat->eph_valid || sat->eph == NULL) // do nothing if no valid ephemeris available
+			continue;
+
+		// ephemeris 0 -- 5  - current toc (see RINEX documentation)
+		toc.Y  = pony_gnss_sat_round(sat->eph[0]);
+		toc.M  = pony_gnss_sat_round(sat->eph[1]);
+		toc.D  = pony_gnss_sat_round(sat->eph[2]);
+		toc.h  = pony_gnss_sat_round(sat->eph[3]);
+		toc.m  = pony_gnss_sat_round(sat->eph[4]);
+		toc.s  =                     sat->eph[5] ;
+		tb_new = pony_gnss_sat_round(toc.h*3600 + toc.m*60 + toc.s);
+		
+		// check tb
+		if (tb[s] < 0 || tb[s] != tb_new) { // new ephemeris have come
+
+			l_n = pony_gnss_sat_round(sat->eph[12]);	// satellite health
+
+			if (l_n) {
+				// drop all flags and skip calculations if SV is not OK
+				sat->eph_valid		= 0;
+				sat->t_em_valid		= 0;
+				sat->x_valid		= 0;
+				sat->v_valid		= 0;
+				sat->sinEl_valid	= 0;
+				tb[s] = -1;
+				continue;
+			}
+
+			tb[s] = tb_new;
+			t [s] = tb_new;
+			for (i = 0, k = 9; i < 3 && k < gnss->glo->max_eph_count-4; i++, k += 4) {
+				x[s][i] = 1e3*sat->eph[k  ];	// coordinates
+				v[s][i] = 1e3*sat->eph[k+1];	// velocity components
+				a[s][i] = 1e3*sat->eph[k+2];	// extra acceleration components
+			}
+			gnss->glo->freq_slot[s]	= pony_gnss_sat_round(sat->eph[16]);	// frequency number
+		}
+
+		tau_n	= -sat->eph[6];	// clock bias
+		gamma_n	=  sat->eph[7];	// clock drift rate
+
+		// check fit interval
+		// (!) intervals only less than 6 hours are supported
+		if (fabs( pony_gnss_sat_epoch_diff_within_day( &(gnss->epoch), &(toc) ) ) >= max_fit_interval) {
+				//sat->eph_valid = 0;
+				continue;
+		}
+
+		// t_em - time of emission 
+		// (!) fit intervals only less than 12 hours are supported yet
+			// toe - time of epoch treated as t_em base approximation
+		sat->t_em = gnss->epoch.h*3600.0 + gnss->epoch.m*60.0 + gnss->epoch.s - ( (gnss->leap_sec_valid)? gnss->leap_sec : 0);
+			// look for any valid code measurement to compensate for travel time
+		ut = 0; // ECEF frame rotation angle
+		for (i = 0; i < gnss->glo->obs_count; i++)
+			if (gnss->glo->obs_types[i][0] == code_id && sat->obs_valid[i]) {
+				ut = sat->obs[i]/pony->gnss_const.c; // base estimate for travel time
+				if (sat->x_valid) // if position is already available, satellite clock correction applies
+					ut += sat->Deltatsv;
+				sat->t_em -= ut; // estimate for the time of emission int hte system time frame
+				sat->t_em_valid = 1;
+
+				if (gnss->sol.dt_valid) // if receiver clock error estimated, receiver clock correction applies
+					ut -= gnss->sol.dt;
+				ut *= pony->gnss_const.glo.u; // ECEF frame rotation angle between emission and reception
+				break;
+			}
+		
+			// satellite position & velocity
+		// (!) fit intervals only less than 12 hours are supported yet
+			// t_em - tb, time elapsed since the time of ephemeris
+		tem_tb = sat->t_em - tb[s];
+		if (tem_tb < -pony->gnss_const.sec_in_d/2) // day rollover - forward
+			tem_tb += pony->gnss_const.sec_in_d;
+		if (tem_tb >  pony->gnss_const.sec_in_d/2) // day rollover - backward
+			tem_tb -= pony->gnss_const.sec_in_d;
+			// tem - t, time elapsed since the last known position
+		tem_t = sat->t_em - t[s];
+		if (tem_t  < -pony->gnss_const.sec_in_d/2) // day rollover - forward
+			tem_t  += pony->gnss_const.sec_in_d;
+		if (tem_t  >  pony->gnss_const.sec_in_d/2) // day rollover - backward
+			tem_t  -= pony->gnss_const.sec_in_d;
+			// choose starting position
+		if ( fabs(tem_tb) < fabs(tem_t) ) { // closer to time of ephemeris -- start from tb
+			t[s] = tb[s];
+			tem_t = tem_tb;
+			for (i = 0, k = 9; i < 3 && k < gnss->glo->max_eph_count-4; i++, k += 4) {
+				x[s][i] = 1e3*sat->eph[k  ];	// coordinates
+				v[s][i] = 1e3*sat->eph[k+1];	// velocity components
+				a[s][i] = 1e3*sat->eph[k+2];	// extra acceleration components
+			}
+		}
+
+			// integrate from t, step 1 sec
+		dt = tem_t;
+		while ( fabs(dt) > max_dt) {
+			dt = (dt > 0)? max_dt : -max_dt;
+			pony_gnss_sat_glo_motion_rk4_step(x[s], v[s], a[s],  dt,  rk4_y, rk4_k);
+			t[s] += dt;
+			dt = sat->t_em - t[s];
+			if (dt < -pony->gnss_const.sec_in_d/2) // day rollover - forward
+				dt += pony->gnss_const.sec_in_d;
+			if (dt >  pony->gnss_const.sec_in_d/2) // day rollover - backward
+				dt -= pony->gnss_const.sec_in_d;
+		}
+		pony_gnss_sat_glo_motion_rk4_step(x[s], v[s], a[s],  dt,  rk4_y, rk4_k);
+		t[s] += dt;
+
+			// radius and speed to be checked
+		for (i = 0, r = 0, vel = 0; i < 3; i++) {
+			r   += x[s][i]*x[s][i];
+			vel += v[s][i]*v[s][i];
+		}
+
+			// rotate the coordinate frame to the time of reception if t_em was corrected
+		cut = cos(ut); 
+		sut = sin(ut);
+		sat->x[0] =  x[s][0]*cut + x[s][1]*sut;
+		sat->x[1] = -x[s][0]*sut + x[s][1]*cut;
+		sat->x[2] =  x[s][2];
+		if (orbit_radius_squared_min < r && r < orbit_radius_squared_max)
+			sat->x_valid = 1;
+		sat->v[0] =  v[s][0]*cut + v[s][1]*sut;
+		sat->v[1] = -v[s][0]*sut + v[s][1]*cut;
+		sat->v[2] =  v[s][2];
+		if (vel < orbital_speed_squared_max)
+			sat->v_valid = 1;
+
+		// SV clock correction as in Section 3.3.3 of ICD GLONASS Edition 5.1 2008, minus sign, tau_c if present in gnss->glo->clock_corr
+		if (gnss->glo->clock_corr_valid && gnss->glo->clock_corr_to[0] == utc_time_id[0] && gnss->glo->clock_corr_to[1] == utc_time_id[1])
+			tau_c = -gnss->glo->clock_corr[0];
+		else
+			tau_c = 0;
+
+		sat->Deltatsv = -tau_n + gamma_n*tem_tb - tau_c;
+
+		// check if position is available to calculate elevation
+		if (sat->x_valid && gnss->sol.x_valid) {
+			for (i = 0, r = 0.0, sat->sinEl = 0; i < 3; i++) {
+				dx = sat->x[i] - gnss->sol.x[i];
+				sat->sinEl += gnss->sol.x[i]*dx;
+				r += dx*dx;
+			}
+			r = sqrt(r);
+			sat->sinEl /= r;
+
+			for (i = 0, r = 0.0; i < 3; i++)
+				r += gnss->sol.x[i]*gnss->sol.x[i];
+			r = sqrt(r);
+			sat->sinEl /= r;
+			sat->sinEl_valid = 1;
+		}
+		else
+			sat->sinEl_valid = 0;
+	}
+
+}
+
+void pony_gnss_sat_glo_motion_rk4_step(double *x, double *v, double *a,  double dt, double *y, double **k) {
+
+	double dt_2, dt_6;
+	size_t i;
+
+	dt_2 = dt/2;
+	dt_6 = dt/6;
+
+	// k1
+	for (i = 0; i < 3; i++) {
+		y[i  ] = x[i];
+		y[3+i] = v[i];
+	}
+	pony_gnss_sat_glo_motion_ode_fun(k[0],  y, a);
+
+	// k2
+	for (i = 0; i < 3; i++) {
+		y[i  ] = x[i] + dt_2*k[0][  i];
+		y[3+i] = v[i] + dt_2*k[0][3+i];
+	}
+	pony_gnss_sat_glo_motion_ode_fun(k[1],  y, a);
+
+	// k3
+	for (i = 0; i < 3; i++) {
+		y[i  ] = x[i] + dt_2*k[1][  i];
+		y[3+i] = v[i] + dt_2*k[1][3+i];
+	}
+	pony_gnss_sat_glo_motion_ode_fun(k[2],  y, a);
+
+	// k4
+	for (i = 0; i < 3; i++) {
+		y[i  ] = x[i] + dt*k[2][  i];
+		y[3+i] = v[i] + dt*k[2][3+i];
+	}
+	pony_gnss_sat_glo_motion_ode_fun(k[3],  y, a);
+
+	// y += dt/6*(k1 + 2*k2 + 2*k3 + k4)
+	for (i = 0; i < 3; i++) {
+		x[i] += dt_6*(k[0][  i] + 2*k[1][  i] + 2*k[2][  i] + k[3][  i]);
+		v[i] += dt_6*(k[0][3+i] + 2*k[1][3+i] + 2*k[2][3+i] + k[3][3+i]);
+	}
+}
+
+	// equations of satellite motion as in ICD GLONASS Edition 5.1 2008
+void pony_gnss_sat_glo_motion_ode_fun(double *dy,  double *y, double *a) {
+
+	double r, r3, r2, mu_r3, J02x3_2xa2_r2, z2_r2x5, w2;
+	size_t i;
+
+	for (i = 0, r = 0; i < 3; i++) {
+		r += y[i]*y[i];
+		dy[i] = y[3+i];																					// dx/dt = Vx, dy/dt = Vy, dz/dt = Vz
+	}
+	r = sqrt(r);																						// r = sqrt(x^2 + y^2 + z^2)
+
+	r2 = r*r;																							// r^2
+	r3 = r2*r;																							// r^3
+	mu_r3 = pony->gnss_const.glo.mu/r3;																	// mu/r^3
+	J02x3_2xa2_r2 = 1.5*pony->gnss_const.glo.J02*pony->gnss_const.glo.a*pony->gnss_const.glo.a/r2;		// 3/2*J02*mu*a^2/r^5
+	z2_r2x5 = 5*y[2]*y[2]/r2;																			// 5*z^2/r^2
+	w2 = pony->gnss_const.glo.u*pony->gnss_const.glo.u;													// w^2
+
+	dy[3] = (-mu_r3*(1 + J02x3_2xa2_r2*(1-z2_r2x5)) + w2)*y[0] + 2*pony->gnss_const.glo.u*y[4]	+ a[0];	// -mu/r^3*x - 3/2*J02*mu*a^2/r^5*x*(1-5*z^2/r^2) + w^2*x + 2*w*Vy + ddx
+	dy[4] = (-mu_r3*(1 + J02x3_2xa2_r2*(1-z2_r2x5)) + w2)*y[1] - 2*pony->gnss_const.glo.u*y[3]	+ a[1];	// -mu/r^3*y - 3/2*J02*mu*a^2/r^5*y*(1-5*z^2/r^2) + w^2*y - 2*w*Vx + ddy
+	dy[5] = (-mu_r3*(1 + J02x3_2xa2_r2*(3-z2_r2x5))     )*y[2]									+ a[2];	// -mu/r^3*z - 3/2*J02*mu*a^2/r^5*z*(3-5*z^2/r^2)                  + ddz
+
+}
+
+	// single-receiver satellite calculations for Galileo
+void pony_gnss_sat_pos_vel_clock_gal_single_receiver(pony_gnss *gnss, double *allIODnav, double *allA, double *alln, double *allE, double **allaf)
+{
+	const char   code_id          = 'C';
+	const double 
+		max_fit_interval          = 6*3600,           // maximum fit interval, seconds
+		anomaly_precision         = 1.0/0xe000000000, // radians, roughly 1e-12
+		orbit_radius_squared_min  = 841e12,           //  m^2
+		orbit_radius_squared_max  = 900e12,           //  m^2
+		orbital_speed_squared_min = 1.2e7,            // (m/s)^2
+		orbital_speed_squared_max = 1.5e7;            // (m/s)^2
+	const int max_iterations      = 32;
+
+	// ephemeris as in Table 60 of Galileo OS SIS ICD Issue 1.2 (November 2015) p. 46
+	// (!) toc fit intervals only less than 24 hours supported yet
+	// (!) toc expressed as pony_time_epoch: Year, Month, Day, hours, minutes, seconds
+	unsigned int DS, week, SVh, tow;
+	pony_time_epoch toc;
+	double BGDE5aE1, BGDE5bE1, SISA, af2, af1, af0;
+
+	// clock correction parameters as in Section 5.1.4 of Galileo OS SIS ICD Issue 1.2 (November 2015) p. 46
+	double t_toc, Deltatr; // Deltatsv
+
+	// ephemeris as in Table 57 of Galileo OS SIS ICD Issue 1.2 (November 2015) p. 43, 
+	// (!) Deltan, Omdot, idot - in rad/s, according to RINEX
+	// (!) M0, Om0, i0, om - in radiands, according to RINEX
+	// (!) toe is seconds of Galileo week, a fractional part to go with week number, according to RINEX
+	double IODnav, Crs, Deltan, M0, Cuc, e, Cus, sqrtA, toe, Cic, Om0, Cis, i0, Crc, om, Omdot, idot;
+
+	// elements of coordinate systems as in Table 58 of Galileo OS SIS ICD Issue 1.2 (November 2015) p. 44, except for pre-calculated ones
+	double // A, 
+		n0, // t, 
+		tk, // n, 
+		M, E, nu, Phi, du, dr, di, u, r, I, x_, y_, Om, x, y, z;
+
+	// their derivatives for velocity calculation
+	double
+		nu_dot, du_dot, dr_dot, di_dot;
+
+	size_t i, s;
+	double sqrt1e2, sinE, one_ecosE, cos2Phi, sin2Phi, cu, su, cOm, sOm, ci, si, R, dx, ut, cut, sut, vr, vu, v0[3], v[3];
+	pony_gnss_sat *sat; // current satellite
+
+	// requires gnss, gal and sat structure to be initialized
+	if (gnss == NULL || gnss->gal == NULL || gnss->gal->sat == NULL)
+		return;
+
+	// run through all galileo satellites
+	for (s = 0; s < gnss->gal->max_sat_count; s++) 
+	{
+		sat = &(gnss->gal->sat[s]);
+		if (!sat->eph_valid || sat->eph == NULL) // do nothing if no valid ephemeris available
+			continue;
+
+		// ephemeris 0 -- 5  - toc (see RINEX documentation)
+		toc.Y	= pony_gnss_sat_round(sat->eph[0]);
+		toc.M	= pony_gnss_sat_round(sat->eph[1]);
+		toc.D	= pony_gnss_sat_round(sat->eph[2]);
+		toc.h	= pony_gnss_sat_round(sat->eph[3]);
+		toc.m	= pony_gnss_sat_round(sat->eph[4]);
+		toc.s	=                     sat->eph[5] ;
+
+		// check fit interval
+		// t - toc, time elapsed since the time of clock
+		// (!) intervals only less than 24 hours are supported
+		t_toc = pony_gnss_sat_epoch_diff_within_day( &(gnss->epoch), &(toc) );
+		if ( fabs( t_toc ) >= max_fit_interval ) {
+				//sat->eph_valid = 0;
+				continue;
+		}
+
+		// all other ephemeris (see RINEX documentation & Galileo interface specifications)
+		af0			=                     sat->eph[ 6] ;
+		af1			=                     sat->eph[ 7] ;
+		af2			=                     sat->eph[ 8] ;
+		IODnav		=                     sat->eph[ 9] ;
+		Crs			=                     sat->eph[10] ;
+		Deltan		=                     sat->eph[11] ;
+		M0			=                     sat->eph[12] ;
+		Cuc			=                     sat->eph[13] ;
+		e			=                     sat->eph[14] ;
+		Cus			=                     sat->eph[15] ;
+		sqrtA		=                     sat->eph[16] ;
+		toe			=                     sat->eph[17] ;
+		Cic			=                     sat->eph[18] ;
+		Om0			=                     sat->eph[19] ;
+		Cis			=                     sat->eph[20] ;
+		i0			=                     sat->eph[21] ;
+		Crc			=                     sat->eph[22] ;
+		om			=                     sat->eph[23] ;
+		Omdot		=                     sat->eph[24] ;
+		idot		=                     sat->eph[25] ;
+		DS			= pony_gnss_sat_round(sat->eph[26]); // Data sources, skip this field, not analyzed yet
+		week		= pony_gnss_sat_round(sat->eph[27]);
+		// spare parameter field here              28
+		SISA		=                     sat->eph[29] ; // Signal in space accuracy, skip this field, not analyzed yet
+		SVh			= pony_gnss_sat_round(sat->eph[30]); // SV health
+		BGDE5aE1	=                     sat->eph[31] ;
+		BGDE5bE1	=                     sat->eph[32] ;
+		tow			= pony_gnss_sat_round(sat->eph[33]);
+
+		if (SVh) {
+				// drop all flags and skip calculations if SV is not OK
+				sat->eph_valid		= 0;
+				sat->t_em_valid		= 0;
+				sat->x_valid		= 0;
+				sat->v_valid		= 0;
+				sat->sinEl_valid	= 0;
+				continue;
+		}
+		// recalculate stored quantities if new issue of data detected
+		if ( pony_gnss_sat_round(IODnav) != pony_gnss_sat_round(allIODnav[s]) ) {
+			allIODnav[s] = IODnav;
+			// quantities that are constant between issues of ephemeris
+			allA [s]	= sqrtA*sqrtA;
+			n0			= sqrt(pony->gnss_const.gal.mu)/(sqrtA*sqrtA*sqrtA);
+			alln [s]	= n0 + Deltan;
+			allaf[s][0]	= af0;
+			allaf[s][1]	= af1;
+			allaf[s][2]	= af2;
+		}
+		
+		// t_em - time of emission 
+		// (!) fit intervals only less than 12 hours are supported yet
+			// toe - time of epoch treated as t_em base approximation
+		sat->t_em = gnss->epoch.h*3600.0 + gnss->epoch.m*60.0 + gnss->epoch.s;
+			// look for any valid code measurement to compensate for travel time
+		ut = 0; // ECEF frame rotation angle
+		for (i = 0; i < gnss->gal->obs_count; i++)
+			if (gnss->gal->obs_types[i][0] == code_id && sat->obs_valid[i]) {
+				ut = sat->obs[i]/pony->gnss_const.c; // base estimate for travel time
+				if (sat->x_valid) // if position is already available, satellite clock correction applies
+					ut += sat->Deltatsv;
+				sat->t_em -= ut; // estimate for the time of emission in the system time frame
+				sat->t_em_valid = 1;
+
+				if (gnss->sol.dt_valid) // if receiver clock error estimated, receiver clock correction applies
+					ut -= gnss->sol.dt;				
+				ut *= pony->gnss_const.gal.u; // ECEF frame rotation angle between emission and reception
+				break;
+			}
+	
+
+		// satellite position
+		// (!) fit intervals only less than 12 hours are supported yet
+
+			// tk - time from ephemeris reference epoch
+		tk = sat->t_em - fmod(toe, pony->gnss_const.sec_in_d);
+		if (tk < -pony->gnss_const.sec_in_d/2) // day rollover - forward
+			tk += pony->gnss_const.sec_in_d;
+		if (tk >  pony->gnss_const.sec_in_d/2) // day rollover - backward
+			tk -= pony->gnss_const.sec_in_d;
+
+			// M - mean anomaly at current time
+		M = M0 + alln[s]*tk; 
+
+			// Kepler equation by iterations
+		if (allE[s] < -10) // if no previous estimate available, take the mean motion
+			allE[s] = M;
+		i = 0;
+		do {	
+			E = allE[s];
+			allE[s] = M + e*sin(E);
+			i++;
+		} while (fabs(E - allE[s]) > anomaly_precision && i < max_iterations);
+
+			// nu - true anomaly
+		sqrt1e2 = sqrt(1-e*e);
+		sinE = sin(E);
+		nu = atan2( sqrt1e2*sinE, cos(E)-e );
+			// Phi - argument of latitude at current time
+		Phi = nu + om;
+			// second harmonic perturbations
+		cos2Phi = cos(2*Phi); sin2Phi = sin(2*Phi);
+		du = Cus*sin2Phi + Cuc*cos2Phi; // du - argument of latitude correction
+		dr = Crs*sin2Phi + Crc*cos2Phi; // dr - radius correction
+		di = Cis*sin2Phi + Cic*cos2Phi; // di - inclination correction
+			// corrected argument of latitude
+		u = Phi + du;
+			// corrected radius
+		one_ecosE = 1 - e*cos(E);
+		r = allA[s]*one_ecosE + dr;
+			// corrected inclination
+		I = i0 + di + idot*tk;
+			// position in orbital plane
+		cu = cos(u); su = sin(u);
+		x_ = r*cu;
+		y_ = r*su;
+			// corrected longitude of ascending node
+		Om = Om0 + (Omdot - pony->gnss_const.gal.u)*tk - pony->gnss_const.gal.u*toe; // gnss->gal_const.u stands for Omedot
+		
+			// Earth-fixed coordinates
+		cOm = cos(Om); sOm = sin(Om); 
+		ci = cos(I); si = sin(I);
+		x = x_*cOm - y_*ci*sOm;
+		y = x_*sOm + y_*ci*cOm;
+		z = y_*si;
+
+		// radius to be checked
+		R = x*x + y*y + z*z;
+
+		// rotate the coordinate frame to the time of reception if t_em was corrected
+		cut = cos(ut); 
+		sut = sin(ut);
+		sat->x[0] =  x*cut + y*sut;
+		sat->x[1] = -x*sut + y*cut;
+		sat->x[2] =  z;
+		if (orbit_radius_squared_min < R && R < orbit_radius_squared_max)
+			sat->x_valid = 1;
+
+		// SV clock correction as in Section 5.1.4 of Galileo OS SIS ICD, Issue 1.2 (November 2015), p. 47
+		// (!) fit intervals only less than 12 hours are supported yet
+			// t_toc = t - t0c is calculated above
+			// relativistic correction
+		Deltatr = pony->gnss_const.gal.F*e*sqrtA*sinE;
+			// SV PRN code phase time offset
+		sat->Deltatsv = allaf[s][0] + allaf[s][1]*t_toc + allaf[s][2]*t_toc*t_toc + Deltatr;
+
+		// check if position is available to calculate elevation
+		if (sat->x_valid && gnss->sol.x_valid) {
+			for (i = 0, R = 0.0, sat->sinEl = 0; i < 3; i++) {
+				dx = sat->x[i] - gnss->sol.x[i];
+				sat->sinEl += gnss->sol.x[i]*dx;
+				R += dx*dx;
+			}
+			R = sqrt(R);
+			sat->sinEl /= R;
+
+			for (i = 0, R = 0.0; i < 3; i++)
+				R += gnss->sol.x[i]*gnss->sol.x[i];
+			R = sqrt(R);
+			sat->sinEl /= R;
+			sat->sinEl_valid = 1;
+		}
+		else
+			sat->sinEl_valid = 0;
+
+		// velocity calculation
+			// derivatives
+		nu_dot = alln[s]*sqrt1e2/(one_ecosE*one_ecosE);
+		du_dot = 2*(Cus*cos2Phi - Cuc*sin2Phi)*nu_dot;
+		dr_dot = 2*(Crs*cos2Phi - Crc*sin2Phi)*nu_dot;
+		di_dot = 2*(Cis*cos2Phi - Cic*sin2Phi)*nu_dot;
+			// absolute velocity components in orbital plane
+		vr = allA[s]*alln[s]*e*sinE/one_ecosE + dr_dot;
+		vu = r*(nu_dot + du_dot);
+		v0[0] =	vr*cu - vu*su;
+		v0[1] = vr*su + vu*cu;
+		v0[2] = r*sin(nu)*(idot + di_dot);
+			// absolute velocity components in ECEF
+		v[0] = v0[0]*cOm -	v0[1]*ci*sOm +	v0[2]*si*sOm;
+		v[1] = v0[0]*sOm +	v0[1]*ci*cOm -	v0[2]*si*cOm;
+		v[2] =				v0[1]*si +		v0[2]*ci;
+			// speed to be checked
+		R = v[0]*v[0] + v[1]*v[1] + v[2]*v[2];
+			// relative to ECEF velocity components
+		sat->v[0] = v[0] + (pony->gnss_const.gal.u - Omdot)*sat->x[1];
+		sat->v[1] = v[1] - (pony->gnss_const.gal.u - Omdot)*sat->x[0];
+		sat->v[2] = v[2];
+
+		if (orbital_speed_squared_min < R && R < orbital_speed_squared_max)
+			sat->v_valid = 1;
+		else
+			sat->v_valid = 0;
+	}
+
+}
+
+	// single-receiver satellite calculations for BeiDou
+void pony_gnss_sat_pos_vel_clock_bds_single_receiver(pony_gnss *gnss, double *allSOW, double *allA, double *alln, double *allE, double **alla)
+{
+	const char code_id            = 'C';
+	const double 		          
+		max_fit_interval          = 6*3600,           // maximum fit interval, seconds
+		anomaly_precision         = 1.0/0xe000000000, // radians, roughly 1e-12
+		orbit_radius_squared_min  = 756e12,           //  m^2
+		orbit_radius_squared_max  = 812e12,           //  m^2
+		orbital_speed_squared_min = 1.2e7,            // (m/s)^2
+		orbital_speed_squared_max = 1.5e7;            // (m/s)^2
+	const int max_iterations      = 32;
+
+	// ephemeris as in Sections 5.2.4.3-5.2.4.6, 5.2.4.8-5.2.4.10 of BeiDou SIS ICD OSS Version 2.1 (November 2016) p. 28,
+	// (!) toc fit intervals only less than 24 hours supported yet
+	// (!) toc expressed as pony_time_epoch: Year, Month, Day, hours, minutes, seconds
+	int SOW, week, URAI, SatH1, AODC;
+	pony_time_epoch toc;
+	double TGD1, TGD2, a2, a1, a0;
+
+	// clock correction parameters as in Section 5.2.4.10 of BeiDou SIS ICD OSS Version 2.1 (November 2016) p. 30
+	double t_toc, Deltatr; // Deltatsv
+
+	// ephemeris as in Sections 5.2.4.11-5.2.4.12 of BeiDou SIS ICD OSS Version 2.1 (November 2016) p. 31,
+	// (!) Deltan, Omdot, idot - in rad/s, according to RINEX
+	// (!) M0, Om0, i0, om - in radiands, according to RINEX
+	// (!) toe is seconds of Beidou week, a fractional part to go with week number, according to RINEX
+	double AODE, Crs, Deltan, M0, Cuc, e, Cus, sqrtA, toe, Cic, Om0, Cis, i0, Crc, om, Omdot, idot;
+
+	// elements of coordinate systems as in Table 5-11 of BeiDou SIS ICD OSS Version 2.1 (November 2016) p. 34, except for pre-calculated ones
+	double // A, 
+		n0, // t, 
+		tk, // n, 
+		Mk, Ek, nuk, Phik, duk, drk, dik, uk, rk, ik, xk_, yk_, Omk, xk, yk, zk;
+
+	// their derivatives for velocity calculation
+	double
+		nuk_dot, duk_dot, drk_dot, dik_dot;
+
+	size_t i, s;
+	double sqrt1e2, sinE, one_ecosE, cos2Phi, sin2Phi, cu, su, cOm, sOm, ci, si, R, dx, ut, cut, sut, vr, vu, v0[3], v[3];
+	pony_gnss_sat *sat; // current satellite
+
+	// requires gnss, bds and sat structure to be initialized
+	if (gnss == NULL || gnss->bds == NULL || gnss->bds->sat == NULL)
+		return;
+
+	// run through all beidou satellites
+	for (s = 0; s < gnss->bds->max_sat_count; s++) 
+	{
+		sat = &(gnss->bds->sat[s]);
+		if (!sat->eph_valid || sat->eph == NULL) // do nothing if no valid ephemeris available
+			continue;
+
+		// ephemeris 0 -- 5  - toc (see RINEX documentation)
+		toc.Y	= pony_gnss_sat_round(sat->eph[0]);
+		toc.M	= pony_gnss_sat_round(sat->eph[1]);
+		toc.D	= pony_gnss_sat_round(sat->eph[2]);
+		toc.h	= pony_gnss_sat_round(sat->eph[3]);
+		toc.m	= pony_gnss_sat_round(sat->eph[4]);
+		toc.s	=                     sat->eph[5] ;
+
+		// check fit interval
+		// t - toc, time elapsed since the time of clock
+		// (!) intervals only less than 24 hours are supported
+		t_toc = pony_gnss_sat_epoch_diff_within_day( &(gnss->epoch), &(toc) );
+		if ( fabs( t_toc ) >= max_fit_interval ) {
+				//sat->eph_valid = 0;
+				continue;
+		}
+
+		// all other ephemeris (see RINEX documentation & BeiDou interface specifications)
+		a0			=                     sat->eph[ 6] ;
+		a1			=                     sat->eph[ 7] ;
+		a2			=                     sat->eph[ 8] ;
+		AODE		=                     sat->eph[ 9] ; // Age of Data, Ephemeris, not analyzed yet
+		Crs			=                     sat->eph[10] ;
+		Deltan		=                     sat->eph[11] ;
+		M0			=                     sat->eph[12] ;
+		Cuc			=                     sat->eph[13] ;
+		e			=                     sat->eph[14] ;
+		Cus			=                     sat->eph[15] ;
+		sqrtA		=                     sat->eph[16] ;
+		toe			=                     sat->eph[17] ;
+		Cic			=                     sat->eph[18] ;
+		Om0			=                     sat->eph[19] ;
+		Cis			=                     sat->eph[20] ;
+		i0			=                     sat->eph[21] ;
+		Crc			=                     sat->eph[22] ;
+		om			=                     sat->eph[23] ;
+		Omdot		=                     sat->eph[24] ;
+		idot		=                     sat->eph[25] ;
+		// spare parameter field here		       26
+		week		= pony_gnss_sat_round(sat->eph[27]);
+		// spare parameter field here		       28
+		URAI		= pony_gnss_sat_round(sat->eph[29]); // User Range Accuracy Index, not analyzed yet
+		SatH1		= pony_gnss_sat_round(sat->eph[30]); // SV health
+		TGD1		=                     sat->eph[31] ;
+		TGD2		=                     sat->eph[32] ;
+		SOW			= pony_gnss_sat_round(sat->eph[33]);
+		AODC		= pony_gnss_sat_round(sat->eph[34]); // Age of Data, Clock, not analyzed yet
+
+		if (SatH1) {
+				// drop all flags and skip calculations if SV is not OK
+				sat->eph_valid		= 0;
+				sat->t_em_valid		= 0;
+				sat->x_valid		= 0;
+				sat->v_valid		= 0;
+				sat->sinEl_valid	= 0;
+				continue;
+		}
+		// recalculate stored quantities if new issue of data detected
+		if ( SOW != pony_gnss_sat_round(allSOW[s]) ) {
+			allSOW[s] = (double)SOW;
+			// quantities that are constant between issues of ephemeris
+			allA[s]		= sqrtA*sqrtA;
+			n0			= sqrt(pony->gnss_const.bds.mu)/(sqrtA*sqrtA*sqrtA);
+			alln[s]		= n0 + Deltan;
+			alla[s][0]	= a0;
+			alla[s][1]	= a1;
+			alla[s][2]	= a2;
+		}
+		
+		// t_em - time of emission 
+		// (!) fit intervals only less than 12 hours are supported yet
+			// toe - time of epoch treated as t_em base approximation
+		sat->t_em = gnss->epoch.h*3600.0 + gnss->epoch.m*60.0 + gnss->epoch.s - pony->gnss_const.bds.leap_sec;
+			// look for any valid code measurement to compensate for travel time
+		ut = 0; // ECEF frame rotation angle
+		for (i = 0; i < gnss->bds->obs_count; i++)
+			if (gnss->bds->obs_types[i][0] == code_id && sat->obs_valid[i]) {
+				ut = sat->obs[i]/pony->gnss_const.c; // base estimate for travel time
+				if (sat->x_valid) // if position is already available, satellite clock correction applies
+					ut += sat->Deltatsv;
+				sat->t_em -= ut; // estimate for the time of emission in the system time frame
+				sat->t_em_valid = 1;
+
+				if (gnss->sol.dt_valid) // if receiver clock error estimated, receiver clock correction applies
+					ut -= gnss->sol.dt;				
+				ut *= pony->gnss_const.bds.u; // ECEF frame rotation angle between emission and reception
+				break;
+			}
+	
+
+		// satellite position
+		// (!) fit intervals only less than 12 hours are supported yet
+
+			// tk - time from ephemeris reference epoch
+		tk = sat->t_em - fmod(toe, pony->gnss_const.sec_in_d);
+		if (tk < -pony->gnss_const.sec_in_d/2) // day rollover - forward
+			tk += pony->gnss_const.sec_in_d;
+		if (tk >  pony->gnss_const.sec_in_d/2) // day rollover - backward
+			tk -= pony->gnss_const.sec_in_d;
+
+			// Mk - mean anomaly at current time
+		Mk = M0 + alln[s]*tk; 
+
+			// Kepler equation by iterations
+		if (allE[s] < -10) // if no previous estimate available, take the mean motion
+			allE[s] = Mk;
+		i = 0;
+		do {	
+			Ek = allE[s];
+			allE[s] = Mk + e*sin(Ek);
+			i++;
+		} while (fabs(Ek - allE[s]) > anomaly_precision && i < max_iterations);
+
+			// nuk - true anomaly
+		sqrt1e2 = sqrt(1-e*e);
+		sinE = sin(Ek);
+		nuk = atan2( sqrt1e2*sinE, cos(Ek)-e );
+			// Phik - argument of latitude at current time
+		Phik = nuk + om;
+			// second harmonic perturbations
+		cos2Phi = cos(2*Phik); sin2Phi = sin(2*Phik);
+		duk = Cus*sin2Phi + Cuc*cos2Phi; // duk - argument of latitude correction
+		drk = Crs*sin2Phi + Crc*cos2Phi; // drk - radius correction
+		dik = Cis*sin2Phi + Cic*cos2Phi; // dik - inclination correction
+			// corrected argument of latitude
+		uk = Phik + duk;
+			// corrected radius
+		one_ecosE = 1 - e*cos(Ek);
+		rk = allA[s]*one_ecosE + drk;
+			// corrected inclination
+		ik = i0 + dik + idot*tk;
+			// position in orbital plane
+		cu = cos(uk); su = sin(uk);
+		xk_ = rk*cu;
+		yk_ = rk*su;
+			// corrected longitude of ascending node
+		Omk = Om0 + (Omdot - pony->gnss_const.bds.u)*tk - pony->gnss_const.bds.u*toe; // gnss->bds_const.u stands for Omedot
+		
+			// Earth-fixed coordinates
+		cOm = cos(Omk); sOm = sin(Omk); 
+		ci = cos(ik); si = sin(ik);
+		xk = xk_*cOm - yk_*ci*sOm;
+		yk = xk_*sOm + yk_*ci*cOm;
+		zk = yk_*si;
+
+		// radius to be checked
+		R = xk*xk + yk*yk + zk*zk;
+
+		// rotate the coordinate frame to the time of reception if t_em was corrected
+		cut = cos(ut); 
+		sut = sin(ut);
+		sat->x[0] =  xk*cut + yk*sut;
+		sat->x[1] = -xk*sut + yk*cut;
+		sat->x[2] =  zk;
+		if (orbit_radius_squared_min < R && R < orbit_radius_squared_max)
+			sat->x_valid = 1;
+
+		// SV clock correction as in Section 5.2.4.10 of BeiDou SIS ICD OSS Version 2.1 (November 2016) p. 29
+		// (!) fit intervals only less than 12 hours are supported yet
+			// t_toc = t - t0c is calculated above
+			// relativistic correction
+		Deltatr = pony->gnss_const.bds.F*e*sqrtA*sinE;
+			// SV PRN code phase time offset
+		sat->Deltatsv = alla[s][0] + alla[s][1]*t_toc + alla[s][2]*t_toc*t_toc + Deltatr;
+
+		// check if position is available to calculate elevation
+		if (sat->x_valid && gnss->sol.x_valid) {
+			for (i = 0, R = 0.0, sat->sinEl = 0; i < 3; i++) {
+				dx = sat->x[i] - gnss->sol.x[i];
+				sat->sinEl += gnss->sol.x[i]*dx;
+				R += dx*dx;
+			}
+			R = sqrt(R);
+			sat->sinEl /= R;
+
+			for (i = 0, R = 0.0; i < 3; i++)
+				R += gnss->sol.x[i]*gnss->sol.x[i];
+			R = sqrt(R);
+			sat->sinEl /= R;
+			sat->sinEl_valid = 1;
+		}
+		else
+			sat->sinEl_valid = 0;
+
+		// velocity calculation
+			// derivatives
+		nuk_dot = alln[s]*sqrt1e2/(one_ecosE*one_ecosE);
+		duk_dot = 2*(Cus*cos2Phi - Cuc*sin2Phi)*nuk_dot;
+		drk_dot = 2*(Crs*cos2Phi - Crc*sin2Phi)*nuk_dot;
+		dik_dot = 2*(Cis*cos2Phi - Cic*sin2Phi)*nuk_dot;
+			// absolute velocity components in orbital plane
+		vr = allA[s]*alln[s]*e*sinE/one_ecosE + drk_dot;
+		vu = rk*(nuk_dot + duk_dot);
+		v0[0] =	vr*cu - vu*su;
+		v0[1] = vr*su + vu*cu;
+		v0[2] = rk*sin(nuk)*(idot + dik_dot);
+			// absolute velocity components in ECEF
+		v[0] = v0[0]*cOm -	v0[1]*ci*sOm +	v0[2]*si*sOm;
+		v[1] = v0[0]*sOm +	v0[1]*ci*cOm -	v0[2]*si*cOm;
+		v[2] =				v0[1]*si +		v0[2]*ci;
+			// speed to be checked
+		R = v[0]*v[0] + v[1]*v[1] + v[2]*v[2];
+			// relative to ECEF velocity components
+		sat->v[0] = v[0] + (pony->gnss_const.bds.u - Omdot)*sat->x[1];
+		sat->v[1] = v[1] - (pony->gnss_const.bds.u - Omdot)*sat->x[0];
+		sat->v[2] = v[2];
+
+		if (orbital_speed_squared_min < R && R < orbital_speed_squared_max)
+			sat->v_valid = 1;
+		else
+			sat->v_valid = 0;
+	}
+
+}
+
+
+
+
+	// service routines
+		// free memory
+void pony_gnss_sat_free_ppointer_gnss_count(void ***ptr) 
+{
+
+	size_t r;
+
+	if (*ptr == NULL) 
+		return;
+	
+	for (r = 0; r < pony->gnss_count; r++)
+		if ( (*ptr)[r] != NULL )
+			free( (*ptr)[r] );
+	free(*ptr);
+	*ptr = NULL;
+
+}
+
+void pony_gnss_sat_free_pppointer_gnss_count_sat_count_gps(void ****ptr) 
+{
+
+	size_t r, s;
+
+	if (*ptr == NULL) 
+		return;
+	
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gnss gps structure initialized
+		if (pony->gnss[r].gps == NULL)
+			continue;
+		for (s = 0; s < pony->gnss[r].gps->max_sat_count; s++)
+			if ( (*ptr)[r][s] != NULL ) {
+				free( (*ptr)[r][s] );
+				(*ptr)[r][s] = NULL;
+			}
+		free( (*ptr)[r] );
+		(*ptr)[r] = NULL;
+	}
+	free(*ptr);
+	*ptr = NULL;
+
+}
+
+void pony_gnss_sat_free_pppointer_gnss_count_sat_count_glo(void ****ptr) 
+{
+
+	size_t r, s;
+
+	if (*ptr == NULL) 
+		return;
+	
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gnss glo structure initialized
+		if (pony->gnss[r].glo == NULL)
+			continue;
+		for (s = 0; s < pony->gnss[r].glo->max_sat_count; s++)
+			if ( (*ptr)[r][s] != NULL ) {
+				free( (*ptr)[r][s] );
+				(*ptr)[r][s] = NULL;
+			}
+		free( (*ptr)[r] );
+		(*ptr)[r] = NULL;
+	}
+	free(*ptr);
+	*ptr = NULL;
+
+}
+
+void pony_gnss_sat_free_pppointer_gnss_count_sat_count_gal(void ****ptr) 
+{
+
+	size_t r, s;
+
+	if (*ptr == NULL) 
+		return;
+	
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gnss gal structure initialized
+		if (pony->gnss[r].gal == NULL)
+			continue;
+		for (s = 0; s < pony->gnss[r].gal->max_sat_count; s++)
+			if ( (*ptr)[r][s] != NULL ) {
+				free( (*ptr)[r][s] );
+				(*ptr)[r][s] = NULL;
+			}
+		free( (*ptr)[r] );
+		(*ptr)[r] = NULL;
+	}
+	free(*ptr);
+	*ptr = NULL;
+
+}
+
+void pony_gnss_sat_free_pppointer_gnss_count_sat_count_bds(void ****ptr) 
+{
+
+	size_t r, s;
+
+	if (*ptr == NULL) 
+		return;
+	
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gnss bds structure initialized
+		if (pony->gnss[r].bds == NULL)
+			continue;
+		for (s = 0; s < pony->gnss[r].bds->max_sat_count; s++)
+			if ( (*ptr)[r][s] != NULL ) {
+				free( (*ptr)[r][s] );
+				(*ptr)[r][s] = NULL;
+			}
+		free( (*ptr)[r] );
+		(*ptr)[r] = NULL;
+	}
+	free(*ptr);
+	*ptr = NULL;
+
+}
+
+
+
+		// allocate memory
+char pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gps(double ***ptr) 
+{
+	size_t r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL) {
+		*ptr = NULL;
+		return 0;
+	}
+
+	*ptr = (double **)calloc( pony->gnss_count, sizeof(double *) );
+	if (*ptr == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gps structure initialized
+		if (pony->gnss[r].gps == NULL)
+			continue;
+		(*ptr)[r] = (double *)calloc( pony->gnss[r].gps->max_sat_count, sizeof(double) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_gps(double ****ptr, const size_t internal_size) 
+{
+	size_t i, r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	*ptr = (double ***)calloc( pony->gnss_count, sizeof(double **) );
+	if (*ptr == NULL)
+		return 0;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gps structure initialized
+		if (pony->gnss[r].gps == NULL)
+			continue;
+		// try to allocate
+		(*ptr)[r] = NULL;
+		(*ptr)[r] = (double **)calloc( pony->gnss[r].gps->max_sat_count, sizeof(double *) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+		
+		for (i = 0; i < pony->gnss[r].gps->max_sat_count; i++) {
+			(*ptr)[r][i] = NULL;
+			(*ptr)[r][i] = (double *)calloc( internal_size, sizeof(double) );
+			if ( (*ptr)[r][i] == NULL )
+				return 0;
+		}
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_dppointer_gnss_count_sat_count_glo(double ***ptr) 
+{
+	size_t r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL) {
+		*ptr = NULL;
+		return 0;
+	}
+
+	*ptr = (double **)calloc( pony->gnss_count, sizeof(double *) );
+	if (*ptr == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires glo structure initialized
+		if (pony->gnss[r].glo == NULL)
+			continue;
+		(*ptr)[r] = (double *)calloc( pony->gnss[r].glo->max_sat_count, sizeof(double) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_ippointer_gnss_count_sat_count_glo(int ***ptr) 
+{
+	size_t r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL) {
+		*ptr = NULL;
+		return 0;
+	}
+
+	*ptr = (int **)calloc( pony->gnss_count, sizeof(int *) );
+	if (*ptr == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires glo structure initialized
+		if (pony->gnss[r].glo == NULL)
+			continue;
+		(*ptr)[r] = (int *)calloc( pony->gnss[r].glo->max_sat_count, sizeof(int) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_dpppointer_gnss_count_sat_count_glo(double ****ptr, const size_t internal_size) 
+{
+	size_t i, r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	*ptr = (double ***)calloc( pony->gnss_count, sizeof(double **) );
+	if (*ptr == NULL)
+		return 0;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires glo structure initialized
+		if (pony->gnss[r].glo == NULL)
+			continue;
+		// try to allocate
+		(*ptr)[r] = NULL;
+		(*ptr)[r] = (double **)calloc( pony->gnss[r].glo->max_sat_count, sizeof(double *) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+		
+		for (i = 0; i < pony->gnss[r].glo->max_sat_count; i++) {
+			(*ptr)[r][i] = NULL;
+			(*ptr)[r][i] = (double *)calloc( internal_size, sizeof(double) );
+			if ( (*ptr)[r][i] == NULL )
+				return 0;
+		}
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_gal(double ***ptr) 
+{
+	size_t r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL) {
+		*ptr = NULL;
+		return 0;
+	}
+
+	*ptr = (double **)calloc( pony->gnss_count, sizeof(double *) );
+	if (*ptr == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gal structure initialized
+		if (pony->gnss[r].gal == NULL)
+			continue;
+		(*ptr)[r] = (double *)calloc( pony->gnss[r].gal->max_sat_count, sizeof(double) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_gal(double ****ptr, const size_t internal_size) 
+{
+	size_t i, r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	*ptr = (double ***)calloc( pony->gnss_count, sizeof(double **) );
+	if (*ptr == NULL)
+		return 0;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires gal structure initialized
+		if (pony->gnss[r].gal == NULL)
+			continue;
+		// try to allocate
+		(*ptr)[r] = NULL;
+		(*ptr)[r] = (double **)calloc( pony->gnss[r].gal->max_sat_count, sizeof(double *) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+		
+		for (i = 0; i < pony->gnss[r].gal->max_sat_count; i++) {
+			(*ptr)[r][i] = NULL;
+			(*ptr)[r][i] = (double *)calloc( internal_size, sizeof(double) );
+			if ( (*ptr)[r][i] == NULL )
+				return 0;
+		}
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_ppointer_gnss_count_sat_count_bds(double ***ptr) 
+{
+	size_t r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL) {
+		*ptr = NULL;
+		return 0;
+	}
+
+	*ptr = (double **)calloc( pony->gnss_count, sizeof(double *) );
+	if (*ptr == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires bds structure initialized
+		if (pony->gnss[r].bds == NULL)
+			continue;
+		(*ptr)[r] = (double *)calloc( pony->gnss[r].bds->max_sat_count, sizeof(double) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+	}
+
+	return 1;
+}
+
+char pony_gnss_sat_alloc_pppointer_gnss_count_sat_count_bds(double ****ptr, const size_t internal_size) 
+{
+	size_t i, r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	*ptr = (double ***)calloc( pony->gnss_count, sizeof(double **) );
+	if (*ptr == NULL)
+		return 0;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		// requires bds structure initialized
+		if (pony->gnss[r].bds == NULL)
+			continue;
+		// try to allocate
+		(*ptr)[r] = NULL;
+		(*ptr)[r] = (double **)calloc( pony->gnss[r].bds->max_sat_count, sizeof(double *) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+		
+		for (i = 0; i < pony->gnss[r].bds->max_sat_count; i++) {
+			(*ptr)[r][i] = NULL;
+			(*ptr)[r][i] = (double *)calloc( internal_size, sizeof(double) );
+			if ( (*ptr)[r][i] == NULL )
+				return 0;
+		}
+	}
+
+	return 1;
+}
+
+
+
+
+		// difference between two epochs not further than 1 day apart
+double pony_gnss_sat_epoch_diff_within_day(pony_time_epoch *t1, pony_time_epoch *t2) {
+
+	double t1s, t2s;
+
+	t1s = t1->h*3600 + t1->m*60 + t1->s;
+	t2s = t2->h*3600 + t2->m*60 + t2->s;
+
+	if (t1->D == t2->D)
+		return t1s - t2s;
+	else if (t1s < t2s) // t1 is assumed in the next day after t2
+		return t1s - t2s + pony->gnss_const.sec_in_d;
+	else				// t1 is assumed in the previous day before t2
+		return t2s - t1s + pony->gnss_const.sec_in_d;
+
+}
+
+		// round to the nearest integer
+int pony_gnss_sat_round(double x) {
+	return ( (int)( x >= 0.0 ? (x + 0.5) : (x - 0.5) ) );
+}

--- a/gnss/pony_gnss_sat.h
+++ b/gnss/pony_gnss_sat.h
@@ -1,0 +1,10 @@
+// Aug-2020
+//
+/*	pony_gnss_sat
+	
+	pony plugins for GNSS satellite-related calculations:
+*/
+void pony_gnss_sat_pos_vel_clock_gps(void); // position, velocity and clock correction for all gps     satellites from ephemeris
+void pony_gnss_sat_pos_vel_clock_glo(void); // position, velocity and clock correction for all glonass satellites from ephemeris
+void pony_gnss_sat_pos_vel_clock_gal(void); // position, velocity and clock correction for all galileo satellites from ephemeris
+void pony_gnss_sat_pos_vel_clock_bds(void); // position, velocity and clock correction for all beidou  satellites from ephemeris

--- a/gnss/pony_gnss_sol.c
+++ b/gnss/pony_gnss_sol.c
@@ -1,0 +1,880 @@
+// Aug-2020
+//
+/*	pony_gnss_sol 
+	
+	pony plugins that provide GNSS navigation solutions:
+
+	- pony_gnss_sol_pos_code
+		Computes conventional least-squares standalone position and clock error from code pseudoranges 
+		for all available receivers/antennas.
+	- pony_gnss_sol_check_elevation_mask
+		Checks if satellites are below elevation mask and drop their measurement validity flags if the case.
+		Multi-receiver/multi-system capable. Stores separate value for each receiver in gnss->settings structure.
+	- pony_gnss_sol_select_observables
+		Sets validity flags for specific observables according to templates in configuration.
+		Template set 'obs_use' enumerates the exclusive selection of observable types to stay valid.
+		Template set 'obs_off' lists observable types subject to exclusion from further calculations.
+*/
+
+#include <stdlib.h>
+#include <math.h>
+
+#include "../pony.h"
+
+// pony bus version check
+#define PONY_GNSS_SOL_BUS_VERSION_REQUIRED 7
+#if PONY_BUS_VERSION < PONY_GNSS_SOL_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+// internal defines
+#define PONY_GNSS_SOL_POS_PRECISION (1.0/0x3000) // approx 10^-4, meters
+#define PONY_GNSS_SOL_POS_MAX_ITERATIONS 32
+#define PONY_GNSS_SOL_MAX_COORD 10e6             // meters
+
+// internal routines
+	// gnss calculations
+void   pony_gnss_sol_pos_code_single_receiver(pony_gnss *gnss, double *x, double *S, double *h, double *K, const size_t m, const size_t maxk);
+	// models
+double pony_gnss_sol_noise_coeff_from_elev(double sinEl);                                  // uniform atmospheric layer, pathlength-proportional noise level
+char   pony_gnss_sol_ecef2llh(double *ecef, double *llh, const double a, const double e2); // ecef cartesian to longitude-latitude-height
+	// observable codes
+size_t pony_gnss_sol_select_observables_read_wildcards(char *dest,  char *src, const size_t src_len, const char *token);
+char   pony_gnss_sol_select_observables_match_wildcard(char *obstype, char *wildcard);
+	// memory handling
+char   pony_gnss_sol_alloc_ppointer_gnss_count(double ***ptr, const size_t internal_size);
+void   pony_gnss_sol_free_ppointer_gnss_count(void ***ptr);
+void   pony_gnss_sol_free_null(void **ptr);                                                // free memory with NULL-check and NULL-assignment
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// plugin definitions
+
+/* pony_gnss_sol_pos_code - pony plugin
+	
+	Computes conventional least-squares standalone position and clock error from code pseudoranges 
+	for all available receivers/antennas. 
+
+	description:
+		- sets sol.x_valid flag to the number of valid measurements used in position estimate;
+		- estimates receiver clock error for each satellite constellation separately, 
+		  then puts average value into sol.dt;
+		- calculates both ECEF and geographical coordinates.
+	uses:
+		pony->gnss_count
+		pony->gnss[].sol.x
+		pony->gnss[].settings.sinEl_mask
+		pony->gnss[].settings.code_sigma
+		pony->gnss[].gps/glo/gal/bds->max_sat_count
+		pony->gnss[].gps/glo/gal/bds->    obs_count
+		pony->gnss[].gps/glo/gal/bds->    obs_types
+		pony->gnss[].gps/glo/gal/bds->sat[].Deltatsv
+		pony->gnss[].gps/glo/gal/bds->sat[].    x
+		pony->gnss[].gps/glo/gal/bds->sat[].    x_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].  obs
+		pony->gnss[].gps/glo/gal/bds->sat[].  obs_valid
+		pony->gnss[].gps/glo/gal/bds->sat[].sinEl
+		pony->gnss[].gps/glo/gal/bds->sat[].sinEl_valid
+	changes:
+		pony->gnss[].sol.  x
+		pony->gnss[].sol.  x_valid
+		pony->gnss[].sol. dt
+		pony->gnss[].sol. dt_valid
+		pony->gnss[].sol.llh
+		pony->gnss[].sol.llh_valid
+	cfg parameters:
+		none
+*/
+void pony_gnss_sol_pos_code(void) {
+
+	const size_t sys_count = 4;    // gps, glonass, galileo and beidou supported
+	const size_t m = 3+sys_count, maxk = (m*m+m)/2;
+
+	static double 
+		**x = NULL, **S = NULL,	// least squares and covariance square root matrix
+		**h = NULL, **K = NULL;	// current observation coefficients in measurement model and Kalman gain
+
+	size_t i, k, r;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0) {
+
+		// allocate memory
+		if (   !pony_gnss_sol_alloc_ppointer_gnss_count(&x,m)
+			|| !pony_gnss_sol_alloc_ppointer_gnss_count(&S,maxk)
+			|| !pony_gnss_sol_alloc_ppointer_gnss_count(&h,m)
+			|| !pony_gnss_sol_alloc_ppointer_gnss_count(&K,m) ) {
+			pony->mode = -1;
+			return;
+		}
+
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			else 
+				for (i = 0; i < m; i++) {
+					pony_linal_u_ij2k(&k, i, i, m);
+					S[r][k] = PONY_GNSS_SOL_MAX_COORD; // initial covariance for solution
+				}
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+
+		// free memory
+		pony_gnss_sol_free_ppointer_gnss_count( (void ***)(&x) );
+		pony_gnss_sol_free_ppointer_gnss_count( (void ***)(&S) );
+		pony_gnss_sol_free_ppointer_gnss_count( (void ***)(&h) );
+		pony_gnss_sol_free_ppointer_gnss_count( (void ***)(&K) );
+
+		return;
+
+	}
+
+	// regular processing
+	else {
+		
+		// run through all receivers
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			else
+				pony_gnss_sol_pos_code_single_receiver(&(pony->gnss[r]), x[r], S[r], h[r], K[r],m,maxk);
+
+	}
+
+}
+
+/* pony_gnss_sol_check_elevation_mask - pony plugin
+	
+	Checks if satellites are below elevation mask and drop their measurement validity flags if the case.
+	Multi-receiver/multi-system capable. Stores separate value for each receiver in gnss->settings structure.
+
+	description:
+		none
+	uses:
+		pony->gnss_count
+		pony->gnss[].gps/glo/gal/bds->max_sat_count
+		pony->gnss[].gps/glo/gal/bds->    obs_count
+		pony->gnss[].gps/glo/gal/bds->sat[].sinEl
+		pony->gnss[].gps/glo/gal/bds->sat[].sinEl_valid
+	changes:
+		pony->gnss[].settings.sinEl_mask
+		pony->gnss[].gps/glo/gal/bds->sat[].  obs_valid
+	cfg parameters:
+		{gnss: elev_mask} - gnss satellite elevation mask, degrees
+			type   : floating point
+			range  : -90 to +90
+			default: +5
+			example: {gnss: elev_mask = 10}
+
+*/
+void pony_gnss_sol_check_elevation_mask(void) {
+
+	enum system_id {gps, glo, gal, bds, sys_count};
+
+	const char   elev_mask_token[] = "elev_mask"; // elevetion mask parameter name in configuration
+	const double elev_mask_default = 5;           // elevation mask default value, degrees
+
+	char *cfg_ptr;                                // pointer to a substring in configuration
+	size_t r, sys, s, i, maxsat, maxobs;
+	pony_gnss_sat *sat;
+
+	// requires gnss structure initialized
+	if (pony->gnss == NULL)
+		return;
+
+	// init
+	if (pony->mode == 0) {
+		
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg != NULL) {
+				// parse alignment duration from configuration string
+				cfg_ptr = pony_locate_token(elev_mask_token, pony->gnss[r].cfg_settings, pony->gnss[r].settings_length, '=');
+				if (cfg_ptr != NULL)
+					pony->gnss[r].settings.sinEl_mask = atof(cfg_ptr);		
+				// if not found or invalid, set to default
+				if (cfg_ptr == NULL || -90 < pony->gnss[r].settings.sinEl_mask || pony->gnss[r].settings.sinEl_mask < 90)
+					pony->gnss[r].settings.sinEl_mask = elev_mask_default;
+				// convert to sine
+				pony->gnss[r].settings.sinEl_mask = sin(pony->gnss[r].settings.sinEl_mask*pony->gnss_const.pi/180);
+			}
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+		// nothing to do here
+	}
+
+	// regular processing
+	else {
+		
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			else
+				for (sys = 0; sys < sys_count; sys++) {
+					maxsat = 0;
+					maxobs = 0;
+					sat = NULL;
+					switch (sys) {
+						case gps:
+							if (pony->gnss[r].gps == NULL)
+								continue;
+							maxsat	= pony->gnss[r].gps->max_sat_count;
+							maxobs	= pony->gnss[r].gps->obs_count;
+							sat		= pony->gnss[r].gps->sat;
+							break;
+						case glo:
+							if (pony->gnss[r].glo == NULL)
+								continue;
+							maxsat	= pony->gnss[r].glo->max_sat_count;
+							maxobs	= pony->gnss[r].glo->obs_count;
+							sat		= pony->gnss[r].glo->sat;
+							break;
+						case gal:
+							if (pony->gnss[r].gal == NULL)
+								continue;
+							maxsat	= pony->gnss[r].gal->max_sat_count;
+							maxobs	= pony->gnss[r].gal->obs_count;
+							sat		= pony->gnss[r].gal->sat;
+							break;
+						case bds:
+							if (pony->gnss[r].bds == NULL)
+								continue;
+							maxsat	= pony->gnss[r].bds->max_sat_count;
+							maxobs	= pony->gnss[r].bds->obs_count;
+							sat		= pony->gnss[r].bds->sat;
+							break;
+						default:
+							continue;
+					}
+					for (s = 0; s < maxsat; s++)
+						if (sat[s].sinEl_valid && sat[s].sinEl < pony->gnss[r].settings.sinEl_mask)
+							for (i = 0; i < maxobs; i++) // drop observation flags if elevation is below the mask
+								sat[s].obs_valid[i] = 0;
+				}
+	}
+
+}
+
+/* pony_gnss_sol_select_observables - pony plugin
+	
+	Sets validity flags for specific observables according to templates in configuration.
+	Template set 'obs_use' enumerates the exclusive selection of observable types to stay valid.
+	Template set 'obs_off' lists observable types subject to exclusion from further calculations.
+
+	description:
+		Designation of observable types must comply with RINEX specifications, case-sensitive, with e.g.
+		- C1C for code pseudoranges on L1 frequency, C/A channel, 
+		- L2X for carrier phase on L2 frequency, codeless, 
+		- ... etc. 
+		See Section 5.1 Observation codes of RINEX v3.02, or similar sections in other versions.
+		'?' (question mark) for wildcard (any character).
+	uses:
+		pony->gnss_count
+		pony->gnss[].gps/glo/gal/bds->max_sat_count
+		pony->gnss[].gps/glo/gal/bds->    obs_count
+	changes:
+		pony->gnss[].gps/glo/gal/bds->sat[].  obs_valid
+	cfg parameters:
+		1. [optional]
+		{gnss:       obs_use } - the exclusive selection of all     observable types to stay valid
+		and/or
+		{gnss: {gps: obs_use}} -                      --"-- gps     --"--
+		and/or
+		{gnss: {glo: obs_use}} -                      --"-- glonass --"--
+		and/or
+		{gnss: {gal: obs_use}} -                      --"-- galileo --"--
+		and/or
+		{gnss: {bds: obs_use}} -                      --"-- beidou  --"--
+			type   : square brackets-enclosed, comma-separated list of three-character templates
+			range  : as of RINEX specification
+			default: none
+			example: {gnss:       obs_use = [C??, L??] } - use only code pseudorange and carrier phase
+			         {gnss: {gps: obs_use = [?1?]      } - use only L1 band in gps
+		2. [optional]
+		{gnss:       obs_off } -         observable types subject to exclusion from further calculations
+		and/or
+		{gnss: {gps: obs_off}} - gps     --"--
+		and/or
+		{gnss: {glo: obs_off}} - glonass --"--
+		and/or
+		{gnss: {gal: obs_off}} - galileo --"--
+		and/or
+		{gnss: {bds: obs_off}} - beidou  --"--
+			type   : square brackets-enclosed, comma-separated list of three-character templates
+			range  : as of RINEX specification
+			default: none
+			example: {gnss:       obs_off = [C2?, L1C] } - exclude code pseudoranges on L2 and C/A carrier phase on L1
+			         {gnss: {glo: obs_off = [??X]      } - exclude all codeless glonass measurements
+*/
+void pony_gnss_sol_select_observables(void) {
+
+	enum system_id {gps, glo, gal, bds, sys_count};
+	const char obs_use_token[] = "obs_use", obs_off_token[] = "obs_off";
+	const size_t wildcard_len = 3;
+
+	static char ***obs_use_wildcards = NULL, ***obs_off_wildcards = NULL;
+	static size_t **obs_use_count = NULL, **obs_off_count = NULL;
+
+	size_t i, j, r, sys, s, cfg_len, maxsat, maxobs, common_use, common_off;
+	char *cfg, (*obstypes)[4];
+	pony_gnss_sat *sat;
+
+	// requires gnss initialized
+	if (pony->gnss == NULL) 
+		return;
+
+	// init
+	if (pony->mode == 0) {
+
+		// allocate memory
+		obs_use_wildcards	= (char  ***)calloc( pony->gnss_count, sizeof(char  **) );
+		obs_off_wildcards	= (char  ***)calloc( pony->gnss_count, sizeof(char  **) );
+		obs_use_count		= (size_t **)calloc( pony->gnss_count, sizeof(size_t *) );
+		obs_off_count		= (size_t **)calloc( pony->gnss_count, sizeof(size_t *) );
+		if (   obs_use_wildcards	== NULL 
+			|| obs_off_wildcards	== NULL 
+			|| obs_use_count		== NULL 
+			|| obs_off_count		== NULL) {
+			pony->mode = -1;
+			return;
+		}
+
+		for (r = 0; r < pony->gnss_count; r++) { // go for all receivers
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			obs_use_wildcards[r] = (char  **)calloc( sys_count, sizeof(char *) );
+			obs_off_wildcards[r] = (char  **)calloc( sys_count, sizeof(char *) );
+			obs_use_count    [r] = (size_t *)calloc( sys_count, sizeof(size_t) );
+			obs_off_count    [r] = (size_t *)calloc( sys_count, sizeof(size_t) );
+			if (   obs_use_wildcards[r] == NULL 
+				|| obs_off_wildcards[r] == NULL 
+				|| obs_use_count	[r] == NULL 
+				|| obs_off_count	[r] == NULL) {
+				pony->mode = -1;
+				return;
+			}
+
+			cfg		= pony->gnss[r].cfg_settings;
+			cfg_len	= pony->gnss[r].settings_length;
+			common_use = pony_gnss_sol_select_observables_read_wildcards(NULL, cfg, cfg_len, obs_use_token);
+			common_off = pony_gnss_sol_select_observables_read_wildcards(NULL, cfg, cfg_len, obs_off_token);
+
+			for (sys = 0; sys < sys_count; sys++) { // go for all systems and the common configuration string
+				switch (sys) {
+					case gps:
+						if (pony->gnss[r].gps == NULL)
+							continue;
+						cfg		= pony->gnss[r].gps->cfg;
+						cfg_len	= pony->gnss[r].gps->cfglength;
+						break;
+					case glo:
+						if (pony->gnss[r].glo == NULL)
+							continue;
+						cfg		= pony->gnss[r].glo->cfg;
+						cfg_len	= pony->gnss[r].glo->cfglength;
+						break;
+					case gal:
+						if (pony->gnss[r].gal == NULL)
+							continue;
+						cfg		= pony->gnss[r].gal->cfg;
+						cfg_len	= pony->gnss[r].gal->cfglength;
+						break;
+					case bds:
+						if (pony->gnss[r].bds == NULL)
+							continue;
+						cfg		= pony->gnss[r].bds->cfg;
+						cfg_len	= pony->gnss[r].bds->cfglength;
+						break;
+					default:
+						continue;
+				}
+				// count number of wildcards first
+				obs_use_count[r][sys] = common_use + pony_gnss_sol_select_observables_read_wildcards(NULL, cfg, cfg_len, obs_use_token);
+				obs_off_count[r][sys] = common_off + pony_gnss_sol_select_observables_read_wildcards(NULL, cfg, cfg_len, obs_off_token);
+
+				obs_use_wildcards[r][sys] = (char *)calloc( obs_use_count[r][sys]*wildcard_len+1, sizeof(char) );
+				obs_off_wildcards[r][sys] = (char *)calloc( obs_off_count[r][sys]*wildcard_len+1, sizeof(char) );
+				if (   obs_use_wildcards[r][sys] == NULL 
+					|| obs_off_wildcards[r][sys] == NULL) {
+					pony->mode = -1;
+					return;
+				}
+				// actually read wildcards from the configuration for a specific constellation
+				pony_gnss_sol_select_observables_read_wildcards(obs_use_wildcards[r][sys], cfg, cfg_len, obs_use_token);
+				pony_gnss_sol_select_observables_read_wildcards(obs_off_wildcards[r][sys], cfg, cfg_len, obs_off_token);
+				// add from the common configuration
+				cfg		= pony->gnss[r].cfg_settings;
+				cfg_len	= pony->gnss[r].settings_length;
+				s = obs_use_count[r][sys] - common_use;
+				pony_gnss_sol_select_observables_read_wildcards(obs_use_wildcards[r][sys] + s*wildcard_len, cfg, cfg_len, obs_use_token);
+				s = obs_off_count[r][sys] - common_off;
+				pony_gnss_sol_select_observables_read_wildcards(obs_off_wildcards[r][sys] + s*wildcard_len, cfg, cfg_len, obs_off_token);
+			}
+		}
+
+	}
+
+	// terminate
+	if (pony->mode < 0) {
+		
+		// free memory
+		for (r = 0; r < pony->gnss_count; r++) {
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			for (sys = 0; sys < sys_count; sys++) {
+				if (obs_use_wildcards != NULL && obs_use_wildcards[r] != NULL)
+					pony_gnss_sol_free_null( (void **)( &(obs_use_wildcards[r][sys]) ) );
+				if (obs_off_wildcards != NULL && obs_off_wildcards[r] != NULL)
+					pony_gnss_sol_free_null( (void **)( &(obs_off_wildcards[r][sys]) ) );
+			}
+			if (obs_use_wildcards != NULL)
+				pony_gnss_sol_free_null( (void **)( &(obs_use_wildcards[r]) ) );
+			if (obs_off_wildcards != NULL)
+				pony_gnss_sol_free_null( (void **)( &(obs_off_wildcards[r]) ) );
+			if (obs_use_count != NULL)
+				pony_gnss_sol_free_null( (void **)( &(obs_use_count    [r]) ) );
+			if (obs_off_count != NULL)
+				pony_gnss_sol_free_null( (void **)( &(obs_off_count    [r]) ) );
+		}
+		pony_gnss_sol_free_null( (void **)(&obs_use_wildcards) );
+		pony_gnss_sol_free_null( (void **)(&obs_off_wildcards) );
+		pony_gnss_sol_free_null( (void **)(&obs_use_count    ) );
+		pony_gnss_sol_free_null( (void **)(&obs_off_count    ) );
+
+	}
+
+	// regular processing
+	else {
+		
+		if (pony->gnss == NULL) // requires gnss initialized
+			return;
+
+		for (r = 0; r < pony->gnss_count; r++)
+			if (pony->gnss[r].cfg == NULL)
+				continue;
+			else
+				for (sys = 0; sys < sys_count; sys++) {
+					switch (sys) {
+						case gps:
+							if (pony->gnss[r].gps == NULL)
+								continue;
+							maxsat		= pony->gnss[r].gps->max_sat_count;
+							sat			= pony->gnss[r].gps->sat;
+							maxobs		= pony->gnss[r].gps->obs_count;
+							obstypes	= pony->gnss[r].gps->obs_types;
+							break;
+						case glo:
+							if (pony->gnss[r].glo == NULL)
+								continue;
+							maxsat		= pony->gnss[r].glo->max_sat_count;
+							sat			= pony->gnss[r].glo->sat;
+							maxobs		= pony->gnss[r].glo->obs_count;
+							obstypes	= pony->gnss[r].glo->obs_types;
+							break;
+						case gal:
+							if (pony->gnss[r].gal == NULL)
+								continue;
+							maxsat		= pony->gnss[r].gal->max_sat_count;
+							sat			= pony->gnss[r].gal->sat;
+							maxobs		= pony->gnss[r].gal->obs_count;
+							obstypes	= pony->gnss[r].gal->obs_types;
+							break;
+						case bds:
+							if (pony->gnss[r].bds == NULL)
+								continue;
+							maxsat		= pony->gnss[r].bds->max_sat_count;
+							sat			= pony->gnss[r].bds->sat;
+							maxobs		= pony->gnss[r].bds->obs_count;
+							obstypes	= pony->gnss[r].bds->obs_types;
+							break;
+						default:
+							continue;
+					}
+
+					for (i = 0; i < maxobs; i++) {
+						// select only those present in obs_use list
+						for (j = 0; j < obs_use_count[r][sys]*wildcard_len; j += wildcard_len)
+							if (!pony_gnss_sol_select_observables_match_wildcard(obstypes[i], obs_use_wildcards[r][sys] + j) ) { // does not match mandatory wildcard
+								for (s = 0; s < maxsat; s++) // drop validity for all satellites
+									sat[s].obs_valid[i] = 0;
+								break;
+							}
+						// exclude those present in obs_off list
+						for (j = 0; j < obs_off_count[r][sys]*wildcard_len; j += wildcard_len)
+							if (pony_gnss_sol_select_observables_match_wildcard(obstypes[i], obs_off_wildcards[r][sys] + j) ) // does match exclusion wildcard
+							{
+								for (s = 0; s < maxsat; s++) // drop validity for all satellites
+									sat[s].obs_valid[i] = 0;
+								break;
+							}
+					}
+				}
+
+	}
+
+}
+
+
+
+
+
+
+// internal routines
+	// gnss calculations
+void pony_gnss_sol_pos_code_single_receiver(pony_gnss *gnss, double *x, double *S, double *h, double *K, const size_t m, const size_t maxk) {
+
+	enum sys_index {gps, glo, gal, bds, sys_count};
+
+	const char code_id = 'C';
+	const double
+		k_sigma = 5,
+		dx2     = PONY_GNSS_SOL_POS_PRECISION*PONY_GNSS_SOL_POS_PRECISION; // m^2
+
+	size_t i, j, k, s, n, sys, maxsat, maxobs, sys_obs[sys_count];
+	pony_gnss_sat *sat;
+	double z, rho, r, sigma, sigma_pos, sigma_clock[sys_count];
+	char v, (*obs_types)[4];
+
+	// check if current coordinates fall within specified range
+	for (k = 0; k < 3 && fabs(gnss->sol.x[k]) <= PONY_GNSS_SOL_MAX_COORD; k++);
+	if (k < 3) { // invalid coordinates detected, set them all to zero
+		for (k = 0; k < 3; k++)
+			gnss->sol.x[k] = 0;
+		gnss->sol.x_valid = 0;
+	}
+
+	// reset validity flag
+	v = 0;
+	for (i = 0; i < PONY_GNSS_SOL_POS_MAX_ITERATIONS; i++) {
+
+		n = 0; // measurements used so far
+
+		// init estimates
+		for (k = 0; k < m; k++)
+			x[k] = 0;
+		for (k = 0; k < maxk; k++)
+			S[k] = 0;
+		for (j = 0; j < m; j++) {
+				pony_linal_u_ij2k(&k, j, j, m);
+				S[k] = PONY_GNSS_SOL_MAX_COORD; // reset estimated coordinate covariances
+		}
+
+		// process measurements
+		for (sys = 0; sys < sys_count; sys++) {
+			sys_obs[sys] = 0;
+			maxsat = 0; 
+			maxobs = 0;
+			obs_types = NULL;
+			sat = NULL;
+			switch (sys) {
+				case gps:
+					if (gnss->gps == NULL) 
+						continue;
+					maxsat		= gnss->gps->max_sat_count;
+					sat			= gnss->gps->sat;
+					maxobs		= gnss->gps->obs_count;
+					obs_types	= gnss->gps->obs_types;
+					break;
+				case glo:
+					if (gnss->glo == NULL)
+						continue;
+					maxsat		= gnss->glo->max_sat_count;
+					sat			= gnss->glo->sat;
+					maxobs		= gnss->glo->obs_count;
+					obs_types	= gnss->glo->obs_types;
+					break;
+				case gal:
+					if (gnss->gal == NULL)
+						continue;
+					maxsat		= gnss->gal->max_sat_count;
+					sat			= gnss->gal->sat;
+					maxobs		= gnss->gal->obs_count;
+					obs_types	= gnss->gal->obs_types;
+					break;
+				case bds:
+					if (gnss->bds == NULL)
+						continue;
+					maxsat		= gnss->bds->max_sat_count;
+					sat			= gnss->bds->sat;
+					maxobs		= gnss->bds->obs_count;
+					obs_types	= gnss->bds->obs_types;
+					break;
+				default:
+					continue;
+			}
+
+			// run through all satellites
+			for (s = 0; s < maxsat; s++) {
+
+				if ( !(sat[s].x_valid) 
+					|| (sat[s].sinEl_valid && sat[s].sinEl < gnss->settings.sinEl_mask) )
+					continue; // skip satellite if its coordinates aren't valid, or elevation angle known and below the mask
+
+				// calculated distance from current solution to satellite
+				rho = 0;
+				for (k = 0; k < 3; k++) 
+					rho += (sat[s].x[k] - gnss->sol.x[k])*(sat[s].x[k] - gnss->sol.x[k]);
+				rho = sqrt(rho);
+
+				// measurement model coefficients
+				for (k = 0; k < 3; k++)
+					h[k] = (sat[s].x[k] - gnss->sol.x[k])/rho;
+				for (; k < m; k++)
+					h[k] = 0;
+				h[3+sys] = -1;
+
+				// run through all measurements
+				for (j = 0; j < maxobs; j++) {
+					// check if valid code observation
+					if ( obs_types[j][0] != code_id || !(sat[s].obs_valid[j]) )
+						continue;
+					// measurement
+					z = rho - sat[s].obs[j] - sat[s].Deltatsv*pony->gnss_const.c;
+					// measurement sigma
+					if (sat[s].sinEl_valid)
+						sigma = gnss->settings.code_sigma*pony_gnss_sol_noise_coeff_from_elev(sat[s].sinEl);
+					else
+						sigma = gnss->settings.code_sigma;
+					// estimate update
+					r = pony_linal_kalman_update(x, S, K, z, h, sigma, m);
+					sys_obs[sys]++;
+					n++; // measurements used
+				}
+			}
+
+		}
+
+		// add cartesian coordinate estimates to current solution
+		for (k = 0; k < 3; k++)
+			gnss->sol.x[k] += x[k];
+
+		// check number of measurements vs number of unknowns
+		if ( n >= 3 + (sys_obs[gps]>0) + (sys_obs[glo]>0) + (sys_obs[gal]>0) + (sys_obs[bds]>0) )
+			v = 1;
+		else
+			break;
+
+		// check to stop iterations
+		if (x[0]*x[0] + x[1]*x[1] + x[2]*x[2] < dx2)
+			break;
+	}
+
+	if (!v || i >= PONY_GNSS_SOL_POS_MAX_ITERATIONS)
+		return; // not enough measurements of iteration limit reached
+
+	// check estimate error covariances
+	for (k = 0, sigma_pos = 0, i = 0; i < 3; k += m-i, i++)
+		sigma_pos += pony_linal_dot(S+k,S+k,m-i);
+	sigma_pos = sqrt(sigma_pos);
+	for (; i < m; k += m-i, i++)
+		sigma_clock[i-3] = sqrt(pony_linal_dot(S+k,S+k,m-i));
+
+	for (sys = 0, gnss->sol.dt = 0, gnss->sol.dt_valid = 0; sys < sys_count; sys++) {
+		if (!sys_obs[sys] || sigma_clock[sys] > k_sigma*gnss->settings.code_sigma)
+			continue;
+		gnss->sol.dt += x[3+sys];
+		gnss->sol.dt_valid++;
+	}
+	if (gnss->sol.dt_valid)
+		gnss->sol.dt = (gnss->sol.dt/gnss->sol.dt_valid)/pony->gnss_const.c; // receiver clock error in seconds
+	else
+		return; // regard position as invalid if the clock error is too large
+
+	if ( sigma_pos > k_sigma*gnss->settings.code_sigma)
+		return; // position considered invalid
+
+	gnss->sol.x_valid = (char)n;
+	gnss->sol.llh_valid = pony_gnss_sol_ecef2llh(gnss->sol.x, gnss->sol.llh, pony->gnss_const.gps.a, pony->gnss_const.gps.e2); // geodetic solution
+
+}
+
+	// models
+double pony_gnss_sol_noise_coeff_from_elev(double sinEl) {
+
+	return 20*(sqrt(0.1 + sinEl*sinEl) - sinEl);
+
+}
+		// ecef cartesian to longitude-latitude-height
+		// a - the Earth ellipsoid semimajor axis, e2 - its eccentricity squared
+		// return value - llh valid/not valid
+char pony_gnss_sol_ecef2llh(double *ecef, double *llh, const double a, const double e2) 
+{
+
+	const double dr2 = PONY_GNSS_SOL_POS_PRECISION*PONY_GNSS_SOL_POS_PRECISION;
+
+	int i;
+	double	r_e2, r_e, a2,
+			s_phi, c_phi, 
+			dphi, dh, 
+			R2, f1, f2;
+
+	r_e2 = ecef[0]*ecef[0] + ecef[1]*ecef[1];
+	r_e = sqrt(r_e2);
+	a2 = a*a;
+
+	// starting approximation
+	llh[0] = atan2(ecef[1],ecef[0]);	
+	llh[1] = atan2(ecef[2],r_e);
+	llh[2] = sqrt(r_e2 + ecef[2]*ecef[2]) - a;
+
+	// solve f1 = 0, f2 = 0 by iterations
+	for (i = 0; i < PONY_GNSS_SOL_POS_MAX_ITERATIONS; i++) {
+
+		// intermediate quantities
+		s_phi = sin(llh[1]);
+		c_phi = cos(llh[1]);
+		R2 = a/sqrt(1-e2*s_phi*s_phi);
+		f1 = r_e - (R2+llh[2])*c_phi;
+		f2 = ecef[2] - ((1-e2)*R2+llh[2])*s_phi;
+
+		// increments
+		dphi	= (f1*s_phi - f2*c_phi)/(R2 + llh[2]);
+		dh		=  f1*c_phi + f2*s_phi;
+
+		llh[1] -= dphi;
+		llh[2] += dh;
+
+		if (dphi*dphi*a2 + dh*dh < dr2)
+			break;
+
+	}
+
+	return (i < PONY_GNSS_SOL_POS_MAX_ITERATIONS && fabs(llh[2]) < PONY_GNSS_SOL_MAX_COORD) ? 1 : 0;
+
+}
+
+	// observable codes
+		// read 3-character observable wildcards from src to dest, returns number of wildcards found, dest == NULL only counts wildcards
+size_t pony_gnss_sol_select_observables_read_wildcards(char *dest,  char *src, const size_t src_len, const char *token) {
+
+	const char delim = '=', quote = '"', brace_open = '{', brace_close = '}', bracket_open = '[', bracket_close = ']';
+	const size_t wildcard_len = 3;
+
+	size_t i, j, k, n, len1;
+
+	for (n = 0; token[n]; n++); // determine token length
+	if (n == 0)
+		return 0;
+	len1 = src_len - n;
+
+	// look for the token
+	for (i = 0, j = 0, k = 0; i < len1 && src[i]; i++) // throughout the string
+		if (src[i] == quote) // skip quoted values
+			for (i++; src[i] && i < len1 && src[i] != quote; i++);
+		else if (src[i] == brace_open) // skip groups
+			for (i++; src[i] && i < len1 && src[i] != brace_close; i++);
+		else {
+			for (j = 0, k = i; j < n && src[k] == token[j]; j++, k++); // check token
+			if (j == n) // token found
+				break;
+		}
+	if (j < n) // token not found
+		return 0;
+
+	// try to parse
+	for (i = k+1; i < src_len && src[i] && src[i] <= ' '; i++); // skip all non-printables
+	if (i >= src_len || src[i] != delim) // no delimiter found
+		return 0; 
+
+	for (i++; i < src_len && src[i] && src[i] <= ' '; i++); // skip delimiter and all non-printables
+	if (i >= src_len || src[i] != bracket_open) // no opening bracket found
+		return 0; 
+
+	for (i++; i < src_len && src[i] && src[i] <= ' '; i++); // skip opening bracket and all non-printables
+	for (n = 0; i < src_len && src[i] && src[i] != bracket_close; ) { // collecting 3-character wildcards
+		for (k = n*wildcard_len, j = 0; j < wildcard_len && i < src_len && src[i] > ' ' && src[i] != bracket_close; k++, j++, i++) {
+			if (dest != NULL)
+				dest[k] = src[i];
+		}
+		if (j == wildcard_len) // full 3-character wildcard copied
+			n++;
+		for (; i < src_len && src[i] > ' ' && src[i] != bracket_close; i++); // skip all excess printables
+		for (; i < src_len && src[i] && src[i] <= ' '; i++); // skip all non-printables
+	}
+
+	if (src[i] != bracket_close)
+		return 0; // no closing bracket found
+
+	return n;
+
+}
+
+		// check if the obstype matched 3-character wildcard
+char pony_gnss_sol_select_observables_match_wildcard(char *obstype, char *wildcard) {
+
+	const size_t wildcard_len = 3;
+	const char anychar = '?';
+
+	size_t i;
+
+	for (i = 0; i < wildcard_len && obstype[i] && wildcard[i] && (wildcard[i] == anychar || obstype[i] == wildcard[i]); i++);
+	
+	return (i == wildcard_len)? 1 : 0;
+}
+
+	// memory handling
+		// free memory with NULL-check and NULL-assignment
+void pony_gnss_sol_free_null(void **ptr) {
+	
+	if (*ptr == NULL)
+		return;
+	
+	free(*ptr);
+	*ptr = NULL;
+
+}
+		// allocate [gnss_count x internal_size ] double array
+char pony_gnss_sol_alloc_ppointer_gnss_count(double ***ptr, const size_t internal_size) {
+
+	size_t r;
+
+	if (*ptr != NULL)
+		return 1; // already allocated
+
+	*ptr = (double **)calloc( pony->gnss_count, sizeof(double *) );
+	if (*ptr == NULL)
+		return 0;
+
+	for (r = 0; r < pony->gnss_count; r++) {
+		(*ptr)[r] = NULL;
+		(*ptr)[r] = (double *)calloc( internal_size, sizeof(double) );
+		if ( (*ptr)[r] == NULL )
+			return 0;
+	}
+
+	return 1;
+}
+
+void pony_gnss_sol_free_ppointer_gnss_count(void ***ptr) {
+
+	size_t r;
+
+	if (*ptr == NULL) 
+		return;
+	
+	for (r = 0; r < pony->gnss_count; r++)
+		pony_gnss_sol_free_null( &((*ptr)[r]) );
+	free(*ptr);
+	*ptr = NULL;
+
+}

--- a/gnss/pony_gnss_sol.h
+++ b/gnss/pony_gnss_sol.h
@@ -1,0 +1,9 @@
+// Aug-2020
+//
+/*	pony_gnss_sol
+	
+	pony plugins that provide GNSS navigation solutions:
+*/
+void pony_gnss_sol_pos_code            (void); // compute standalone position and clock error from code pseudoranges for all available receivers/antennas
+void pony_gnss_sol_check_elevation_mask(void); // checks if satellites are below elevation mask and drop validity flags if they are
+void pony_gnss_sol_select_observables  (void); // selects observables according to templates in configuration: obs_use and obs_off

--- a/ins/pony_ins_alignment.c
+++ b/ins/pony_ins_alignment.c
@@ -1,0 +1,627 @@
+// Aug-2020
+//
+/*	pony_ins_alignment 
+	
+	pony plugins for ins initial alignment (initial attitude matrix determination):
+	
+	- pony_ins_alignment_static
+		Conventional averaging of accelerometer and gyroscope outputs.
+		Then constructing the attitude matrix out of those averages.
+		Also calculates attitude angles (roll, pitch, yaw=true heading), and quaternion.
+		Recommended for navigation/tactical-grade systems on a highly stable static base,
+		e.g. turntable or stabilized plate.
+
+	- pony_ins_alignment_rotating
+		Approximation of gravity vector rotating along with the Earth in an inertial reference frame.
+		Then estimating northern direction via gravity vector displacement.
+		Also calculates attitude angles (roll, pitch, yaw=true heading), and quaternion.
+		Recommended for navigation-grade systems on a rotating base, 
+		allowing vibrations with zero average acceleration,
+		e.g. an airplane standing still on the ground with engine(s) running.
+
+	- pony_ins_alignment_rotating_rpy
+		The same as pony_ins_alignment_rotating, but attitude matrix is calculated using attitude angles
+		(roll, pitch and yaw=true heading). Does not allow the first instrumental axis to point upwards.
+*/
+
+#include <math.h>
+
+#include "../pony.h"
+
+// pony bus version check
+#define PONY_INS_ALIGNMENT_BUS_VERSION_REQUIRED 8
+#if PONY_BUS_VERSION < PONY_INS_ALIGNMENT_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+/* pony_ins_alignment_static - pony plugin
+	
+	Conventional averaging of accelerometer and gyroscope outputs.
+	Then constructing the attitude matrix out of those averages.
+	Also calculates attitude angles (roll, pitch, yaw=true heading).
+	Recommended for navigation-grade systems on a highly stable static base,
+	e.g. turntable or stabilized plate.
+
+	description:
+		    [  <w> x <f>  | <f> x (<w> x <f>) |  <f>  ]
+		L = [ ----------- | ----------------- | ----- ],
+		    [ |<w> x <f>| | |<f>| |<w> x <f>| | |<f>| ]
+		where <w> and <f> are the angular rate and specific force vectors, respectively,
+		as measured by gyroscopes and accelerometers, averaged over an initial alignment period 
+		specified in the configuration string, u x v is vector cross product
+	
+	uses:
+		pony->imu->t
+		pony->imu->w
+		pony->imu->w_valid
+		pony->imu->f
+		pony->imu->f_valid
+
+	changes:
+		pony->imu->sol.L
+		pony->imu->sol.L_valid
+		pony->imu->sol.q
+		pony->imu->sol.q_valid
+		pony->imu->sol.rpy
+		pony->imu->sol.rpy_valid
+
+	cfg parameters:
+		{imu: alignment} - imu initial alignment duration, sec
+			type :   floating point
+			range:   0+ to +inf
+			default: 300
+			example: {imu: alignment = 900}
+*/
+void pony_ins_alignment_static(void) {
+
+	const char   t0_token[] = "alignment"; // alignment duration parameter name in configuration
+	const double t0_default = 300;         // default alignment duration
+
+	static double 
+		w [3]	= {0,0,0},  // average angular rate measured by gyroscopes <w>
+		f [3]	= {0,0,0},  // average specific force vector measured by accelerometers <f>
+		v [3]	= {0,0,0},  // cross product <w> x <f>
+		vv[3]	= {0,0,0},  // double cross product <f> x (<w> x <f>)
+		d [3]	= {0,0,0},  // vector magnitudes
+		*L	    = NULL,     // pointer to attitude matrix in solution
+		t0      = -1;       // alignment duration
+	static int n = 0;       // measurement counter
+
+	char   *cfg_ptr;        // pointer to a substring in configuration
+	double  n1_n;           // (n - 1)/n
+	size_t  i, j;			// common index variables
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// init values
+		n = 0;                // drop the counter on init
+		L = pony->imu->sol.L; // set pointer to imu solution matrix
+		// parse alignment duration from configuration string
+		cfg_ptr = pony_locate_token(t0_token, pony->imu->cfg, pony->imu->cfglength, '=');
+		if (cfg_ptr != NULL)
+			t0 = atof(cfg_ptr);		
+		// if not found or invalid, set to default
+		if (cfg_ptr == NULL || t0 <= 0)
+			t0 = t0_default;
+
+	}
+	else if (pony->mode < 0) {	// terminate
+		// do nothing
+	}
+	else						// main cycle
+	{
+		// check if alignment duration exceeded 
+		if (pony->imu->t > t0)
+			return;
+		// drop validity flags
+		pony->imu->sol.L_valid		= 0;
+		pony->imu->sol.q_valid		= 0;
+		pony->imu->sol.rpy_valid	= 0;
+		// renew averages, cross products and their lengths
+		if (pony->imu->w_valid && pony->imu->f_valid) {
+			n++;
+			n1_n = (n - 1.0)/n;
+			for (i = 0; i < 3; i++) {
+				w[i] = w[i]*n1_n + pony->imu->w[i]/n;
+				f[i] = f[i]*n1_n + pony->imu->f[i]/n;
+			}
+
+			pony_linal_cross3x1(v , w, f);	d[0] = pony_linal_vnorm(v , 3);
+			pony_linal_cross3x1(vv, f, v);	d[1] = pony_linal_vnorm(vv, 3);
+											d[2] = pony_linal_vnorm(f , 3);
+		}
+		// check for singularity
+		for (i = 0; i < 3; i++)
+			if (d[i] <= 0) // attitude undefined
+				return;
+		// renew attitude matrix
+		for (i = 0, j = 0; j < 3; i += 3, j++) {
+			L[i + 0] = v [j]/d[0];
+			L[i + 1] = vv[j]/d[1];
+			L[i + 2] = f [j]/d[2];
+		}
+		pony->imu->sol.L_valid   = 1;
+		// renew quaternion
+		pony_linal_mat2quat(pony->imu->sol.q  , pony->imu->sol.L);
+		pony->imu->sol.q_valid   = 1;
+		// renew angles
+		pony_linal_mat2rpy (pony->imu->sol.rpy, pony->imu->sol.L);
+		pony->imu->sol.rpy_valid = 1;
+
+	}
+
+}
+
+/* pony_ins_alignment_rotating - pony plugin
+	
+	Approximation of gravity vector rotating along with the Earth in an inertial reference frame.
+	Then estimating northern direction via gravity vector displacement.
+	Also calculates attitude angles (roll, pitch, yaw=true heading).
+	Recommended for navigation-grade systems on a rotating base, 
+	allowing vibrations with zero average acceleration,
+	e.g. an airplane standing still on the ground with engine(s) running.
+
+	description:
+		algorithm may be found in a separate document [A. Kozlov]
+
+		takes latitude from imu solution, if valid
+		else takes latitude from hybrid solution
+		otherwise quits
+	
+	uses:
+		pony->imu->t
+		pony->imu->w
+		pony->imu->w_valid
+		pony->imu->f
+		pony->imu->f_valid
+		pony->imu->sol.llh
+		pony->imu->sol.llh_valid
+		pony->     sol.llh
+		pony->     sol.llh_valid
+
+	changes:
+		pony->imu->sol.L
+		pony->imu->sol.L_valid
+		pony->imu->sol.q
+		pony->imu->sol.q_valid
+		pony->imu->sol.rpy
+		pony->imu->sol.rpy_valid
+
+	cfg parameters:
+		{imu: alignment} - imu initial alignment duration, sec
+			type :   floating point
+			range:   0+ to +inf
+			default: 900
+			example: {imu: alignment = 300}
+*/
+void pony_ins_alignment_rotating(void) {
+
+	const char   
+		t1_token[] = "alignment"; // alignment duration parameter name in configuration
+	const double 
+		t1_default = 900,         // default alignment duration
+		v_std      = 1,           // velocity integral standard deviation
+		S0         = 9e9,         // starting covariances
+		q2_std     = 9;           // Earth rotation axis ort dispersion, rad^2/Hz
+	const size_t 
+		m      = 3;	              // approximation coefficient count
+
+	static double 
+		*L		= NULL, // pointer to attitude matrix in solution
+		t1      = -1,   // alignment duration
+		t_prev  = -1,   // previous time
+		t0      = -1,   // alignment start time
+		t_shift =  0,   // time since the alignment started
+		slt     =  0,   //   sine of latitude
+		clt     =  0,   // cosine of latitude
+		fz0  [3],       // accelerometers output and their approximation in inertial frame
+		vz0  [3],       // velocity integral
+		fz0a0[3],       // approximation at t0
+		fza  [3],       // approximation at current time in instrumental frame
+		a    [3],       // Euler vector of rotation from inertial to instrumental reference frame
+		C    [9],       // intermediate transition matrix
+		Azz0 [9],       // transition matrix from inertial to instrumental reference frame
+		x    [3][3],    // approximation coefficients
+		 Sx  [3][6],    // upper-triangular part of Colesky factorization of approximation coefficients covariance
+		 Kx  [3],       // approximation Kalman gain
+		 hx  [3],       // approximation model matrix
+		  y  [3],       // Earth rotation axis ort estimate
+		 Sy  [6],       // upper-triangular part of Colesky factorization of Earth rotation axis ort covariance
+		 hy  [3],       // Earth rotation axis ort model matrix
+		 Ky  [3],       // Earth rotation axis ort Kalman gain
+		 wf  [3],       // first column of attitude matrix
+		fwf  [3];       // second column of attitude matrix
+					    
+	double 			    
+		   dt,          // time increment
+		   ut,          // Earth rotation angle
+		  sut, cut,     // sine and cosine of Earth rotation angle
+		  n,            // vector norm
+		  q2;           // Earth rotation axis ort dispersion, rad^2
+	char *cfg_ptr;      // pointer to a substring in configuration
+	size_t 			    
+		  i, j, k, k0;  // common indexing variables
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// reset time variables
+		t_prev  = -1;
+		t0      = -1;
+		t_shift =  0;
+		// parse alignment duration from configuration string
+		cfg_ptr = pony_locate_token(t1_token, pony->imu->cfg, pony->imu->cfglength, '=');
+		if (cfg_ptr != NULL)
+			t1 = atof(cfg_ptr);		
+		// if not found or invalid, set to default
+		if (cfg_ptr == NULL || t1 <= 0)
+			t1 = t1_default;
+		// set matrix pointer to imu->sol
+		L = pony->imu->sol.L;
+
+	}
+
+	else if (pony->mode < 0) {	// terminate
+		// do nothing
+	}
+
+	else						// main cycle
+	{
+		// check if alignment duration exceeded 
+		if (pony->imu->t > t1)
+			return;
+		// check for crucial data present
+		if (   !pony->imu->      w_valid     // check if angular rate measurements are available
+			|| !pony->imu->      f_valid     // check if accelerometer measurements are available
+			|| (   !pony->imu->sol.llh_valid // check if imu coordinates are available
+			    && !pony->     sol.llh_valid // check if hybrid solution coordinates are available
+			   )
+			)
+			return;
+		// starting procedures
+		if (t_prev < 0) {
+			// time init
+			t_prev = pony->imu->t;
+			t0     = pony->imu->t;
+			// identity attitude matrix
+			for (i = 0; i < 9; i++)
+				Azz0[i] = (i%4 == 0) ? 1 : 0;
+			// component-wise init
+			for (i = 0; i < 3; i++) {
+				// velocity integral
+				vz0[i] = 0;
+				// starting estimates and covariances for approximation
+				for (j = 0, k = 0; j < m; j++) {
+					 x[i][j] = 0;
+					Sx[i][k] = S0;
+					k0 = k + m - j;
+					for (k++; k < k0; k++) Sx[i][k] = 0;
+				}
+			}
+			// starting estimates and covariances for Earth rotation axis ort
+			for (j = 0, k = 0; j < 3; j++) {
+				 y[j] = 0;
+				Sy[k] = S0;
+				k0 = k + 3 - j;
+				for (k++; k < k0; k++) Sy[k] = 0;
+			}
+			// latitude
+			if (pony->imu->sol.llh_valid) { // if imu coordinates are available
+				slt    = sin(pony->imu->sol.llh[1]);
+				clt    = cos(pony->imu->sol.llh[1]);
+			}
+			else if (pony->sol.llh_valid) { // if hybrid solution coordinates are available
+				slt    = sin(pony->     sol.llh[1]);
+				clt    = cos(pony->     sol.llh[1]);
+			}
+			return;
+		}
+		// time increments
+		dt      = pony->imu->t - t_prev; 
+		if (dt <= 0) return; // invalid increment, aborting
+		t_prev  = pony->imu->t;
+		t_shift = pony->imu->t - t0;
+		q2 = q2_std/dt;
+		// Earth rotation angle
+		 ut = pony->imu_const.u*t_shift;
+		sut = sin(ut);
+		cut = cos(ut);
+		// transforming into inertial frame fz0 = A^T*fz
+		pony_linal_mmul1T(fz0, Azz0, pony->imu->f, 3, 3, 1);
+		// approximation model coefficients
+		hx[0] = (1 - cut)/(pony->imu_const.u*pony->imu_const.u);  
+		hx[1] =   sut    / pony->imu_const.u;  
+		hx[2] = t_shift;
+		// approximation
+		for (i = 0; i < 3; i++) {
+			// velocity interal update
+			vz0[i] += fz0[i]*dt;
+			// approiximation coefficient estimates
+			if (pony_linal_check_measurement_residual(x[i],Sx[i], vz0[i],hx,v_std, 3.0, m)) // check measurement residual within 3-sigma with current estimate
+				pony_linal_kalman_update(x[i],Sx[i],Kx, vz0[i],hx,v_std, m);                // update estimates using v = h*x + dv, v_std = sqrt(E[dv^2])
+			// approximation at t0 in inertial frame
+			fz0a0[i] = x[i][1] + x[i][2];
+			// approximation at t  in inertial frame
+			fz0[i] = x[i][0]*sut/pony->imu_const.u + x[i][1]*cut + x[i][2];
+		}
+		// transition to instrumental frame (fza = Azz0*fz0) and normalization
+		pony_linal_mmul(fza , Azz0, fz0 , 3, 3, 1);
+		n = pony_linal_vnorm(fza,3);                    // n = |fza|
+		if (n > 0) for (i = 0; i < 3; i++) fza[i] /= n; // normalization
+		pony_linal_mmul(fz0, Azz0, fz0a0, 3, 3, 1);
+		n = pony_linal_vnorm(fz0,3);                    // n = |fz0|
+		if (n > 0) for (i = 0; i < 3; i++) fz0[i] /= n; // normalization
+		// estimating Earth rotation axis ort
+		C[0] =        - sut;
+		C[1] = slt*(1 - cut);
+		C[2] = slt*slt + clt*clt*cut;
+		for (i = 0; i < 3; i++) {
+			// H = (w x f)*C_13 + [f x (w x f)]*C_23
+			hy[(i+0)%3] = (fza[(i+1)%3]*fza[(i+1)%3] + fza[(i+2)%3]*fza[(i+2)%3])*C[1];
+			hy[(i+1)%3] =  fza[(i+2)%3]*C[0]         - fza[(i+0)%3]*fza[(i+1)%3] *C[1];
+			hy[(i+2)%3] = -fza[(i+1)%3]*C[0]         - fza[(i+0)%3]*fza[(i+2)%3] *C[1];
+			pony_linal_kalman_update(y,Sy,Ky, (fz0[i]-fza[i]*C[2])*sin(ut/2),hy,1, 3); // update estimate using z = [fza0 - fza*C_33], z = H*y + r, M[r^2] = 1
+		}
+		// Kalman prediction step, identity transition, diagonal system noise covariance
+		pony_linal_kalman_predict_I_qI(Sy,q2,3); // P = S*S^T, P_ii = P_ii + q^2, S = chol(P)
+		// renew attitude matrix: L = [ (w x f)/|w x f| , (f x (w x f))/(|f||w x f|) , f/|f| ]
+		pony_linal_cross3x1( wf, y,fza); //  wf =      w x f
+		n = pony_linal_vnorm(wf,3);      //   n =     |w x f|
+		if (n > 0) {
+			for (i = 0; i < 3; i++) L[i*3+0] =  wf[i]/n; // L1 =      (w x f) /    |w x f|
+			pony_linal_cross3x1(fwf,fza,wf); // fwf = f x (w x f)
+			for (i = 0; i < 3; i++) L[i*3+1] = fwf[i]/n; // L2 = (f x (w x f))/(|f||w x f|)
+			for (i = 0; i < 3; i++) L[i*3+2] = fza[i];   // L3 =           f  / |f|
+			pony->imu->sol.L_valid = 1;
+			// renew quaternion
+			pony_linal_mat2quat(pony->imu->sol.q ,L);
+			pony->imu->sol.q_valid   = 1;
+			// renew angles: roll, pitch and yaw=true heading
+			pony_linal_mat2rpy(pony->imu->sol.rpy,L);
+			pony->imu->sol.rpy_valid = 1;
+		}
+		// instrumental frame update: Azz0(t+dt) = (E + [w x]*sin(|w*dt|)/|w| + [w x]^2*(1-cos(|w*dt|)/|w*dt|^2)*Azz0(t) - Rodrigues' rotation formula
+		for (i = 0; i < 3; i++)
+			a[i] = pony->imu->w[i]*dt; // a = w*dt
+		pony_linal_eul2mat(C,a);       // C = E + [a x]*sin(|a|)/|a| + [a x]^2*(1-cos(|a|)/|a|^2
+		for (i = 0; i < 3; i++) {      // matrix multiplication overwriting Azz0
+			for (j = 0; j < 3; j++)
+				a[j] = Azz0[j*3+i];    // i-th column of Azz0 previous value
+			for (j = 0; j < 3; j++)
+				for (k = 0, Azz0[j*3+i] = 0; k < 3; k++)
+					Azz0[j*3+i] += C[j*3+k]*a[k]; // replace column with matrix product: Azz0(t+dt) = C*Azz0(t)
+		}
+
+	}
+
+}
+
+/* pony_ins_alignment_rotating_rpy - pony plugin
+	
+	The same as pony_ins_alignment_rotating, but attitude matrix is calculated using attitude angles
+	(roll, pitch and yaw=true heading). Does not allow the first instrumental axis to point upwards.
+
+	description:
+		algorithm may be found in a separate document [A.A. Golovan]
+
+		takes latitude from imu solution, if valid
+		else takes latitude from hybrid solution
+		otherwise quits
+	
+	uses:
+		pony->imu->t
+		pony->imu->w
+		pony->imu->w_valid
+		pony->imu->f
+		pony->imu->f_valid
+		pony->imu->sol.llh
+		pony->imu->sol.llh_valid
+		pony->     sol.llh
+		pony->     sol.llh_valid
+
+	changes:
+		pony->imu->sol.L
+		pony->imu->sol.L_valid
+		pony->imu->sol.q
+		pony->imu->sol.q_valid
+		pony->imu->sol.rpy
+		pony->imu->sol.rpy_valid
+
+	cfg parameters:
+		{imu: alignment} - imu initial alignment duration, sec
+			type :   floating point
+			range:   0+ to +inf
+			default: 900
+			example: {imu: alignment = 300}
+*/
+void pony_ins_alignment_rotating_rpy(void) {
+
+	const char   
+		t1_token[] = "alignment"; // alignment duration parameter name in configuration
+	const double 
+		t1_default = 900,         // default alignment duration
+		v_std      = 1,           // velocity integral standard deviation
+		S0         = 9e9;         // starting covariances
+	const size_t 
+		m      = 3;	              // approximation coefficient count
+
+	static double 
+		t1      = -1,  // alignment duration
+		t_prev  = -1,  // previous time
+		t0      = -1,  // alignment start time
+		t_shift =  0,  // time since the alignment started
+		slt     =  0,  //   sine of latitude
+		clt     =  0,  // cosine of latitude
+		fz0  [3],      // accelerometers output and their approximation in inertial frame
+		vz0  [3],      // velocity integral
+		rpy0 [3],      // initial roll, pitch and yaw=true heading
+		fz0a0[3],      // approximation at t0
+		fza  [3],      // approximation at current time in instrumental frame
+		a    [3],      // Euler vector of rotation from inertial to instrumental reference frame
+		C    [9],      // intermediate transition matrix
+		D    [9],      // intermediate transition matrix
+		L0   [9],      // initial attitude matrix
+		Azz0 [9],      // transition matrix from inertial to instrumental reference frame
+		x    [3][3],   // approximation coefficients
+		 Sx  [3][6],   // upper-triangular part of Colesky factorization of approximation coefficients covariance
+		 Kx  [3],      // approximation Kalman gain
+		 hx  [3];      // approximation model matrix
+
+	double 
+		   dt,         // time increment
+		   ut,         // Earth rotation angle
+		  sut, cut;    // sine and cosine of Earth rotation angle
+	char *cfg_ptr;     // pointer to a substring in configuration
+	size_t 
+		  i, j, k, k0; // common indexing variables
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// reset time variables
+		t_prev  = -1;
+		t0      = -1;
+		t_shift =  0; 
+		// parse alignment duration from configuration string
+		cfg_ptr = pony_locate_token(t1_token, pony->imu->cfg, pony->imu->cfglength, '=');
+		if (cfg_ptr != NULL)
+			t1 = atof(cfg_ptr);		
+		// if not found or invalid, set to default
+		if (cfg_ptr == NULL || t1 <= 0)
+			t1 = t1_default;
+
+	}
+
+	else if (pony->mode < 0) {	// terminate
+		// do nothing
+	}
+
+	else						// main cycle
+	{
+		// check if alignment duration exceeded 
+		if (pony->imu->t > t1)
+			return;
+		// check for crucial data present
+		if (   !pony->imu->      w_valid     // check if angular rate measurements are available
+			|| !pony->imu->      f_valid     // check if accelerometer measurements are available
+			|| (   !pony->imu->sol.llh_valid // check if imu coordinates are available
+			    && !pony->     sol.llh_valid // check if hybrid solution coordinates are available
+			   )
+			)
+			return;
+		// starting procedures
+		if (t_prev < 0) {
+			// time init
+			t_prev = pony->imu->t;
+			t0     = pony->imu->t;
+			// identity attitude matrix
+			for (i = 0; i < 9; i++)
+				Azz0[i] = (i%4 == 0) ? 1 : 0;
+			// component-wise init
+			for (i = 0; i < 3; i++) {
+				// velocity integral
+				vz0[i] = 0;
+				// starting estimates and covariances for approximation
+				for (j = 0, k = 0; j < m; j++) {
+					 x[i][j] = 0;
+					Sx[i][k] = S0;
+					k0 = k + m - j;
+					for (k++; k < k0; k++) Sx[i][k] = 0;
+				}
+			}
+			// latitude
+			if (pony->imu->sol.llh_valid) { // if imu coordinates are available
+				slt    = sin(pony->imu->sol.llh[1]);
+				clt    = cos(pony->imu->sol.llh[1]);
+			}
+			else if (pony->sol.llh_valid) { // if hybrid solution coordinates are available
+				slt    = sin(pony->     sol.llh[1]);
+				clt    = cos(pony->     sol.llh[1]);
+			}
+			return;
+		}
+		// time increments
+		dt      = pony->imu->t - t_prev; 
+		if (dt <= 0) return; // invalid increment, aborting
+		t_prev  = pony->imu->t;
+		t_shift = pony->imu->t - t0;
+		// Earth rotation angle
+		 ut = pony->imu_const.u*t_shift;
+		sut = sin(ut);
+		cut = cos(ut);
+		// transforming into inertial frame fz0 = A^T*fz
+		pony_linal_mmul1T(fz0, Azz0, pony->imu->f, 3, 3, 1);
+		// approximation model coefficients
+		hx[0] = (1 - cut)/(pony->imu_const.u*pony->imu_const.u);  
+		hx[1] =   sut    / pony->imu_const.u;  
+		hx[2] = t_shift;
+		// approximation
+		for (i = 0; i < 3; i++) {
+			// velocity interal update
+			vz0[i] += fz0[i]*dt;
+			// approiximation coefficient estimates
+			if (pony_linal_check_measurement_residual(x[i],Sx[i], vz0[i],hx,v_std, 3.0, m)) // check measurement residual within 3-sigma with current estimate
+				pony_linal_kalman_update(x[i],Sx[i],Kx, vz0[i],hx,v_std, m);                // update estimates using v = h*x + dv, v_std = sqrt(E[dv^2])
+			// approximation at t0 in inertial frame
+			fz0a0[i] = x[i][1] + x[i][2];
+			// approximation at t  in inertial frame
+			fz0[i] = x[i][0]*sut/pony->imu_const.u + x[i][1]*cut + x[i][2];
+		}
+		// transition to instrumental frame (fza = Azz0*fz0) and normalization
+		pony_linal_mmul(fza , Azz0, fz0 , 3, 3, 1);
+		// roll angle via fza components
+		pony->imu->sol.rpy[0] = -atan2(fza[2], fza[1]);
+		// pitch angle via fza components
+		pony->imu->sol.rpy[1] =  atan2(fza[0], sqrt(fza[1]*fza[1] + fza[2]*fza[2]));
+		// heading, main branch
+		// initial roll and pitch, zero heading
+		rpy0[0] = -atan2(fz0a0[2], fz0a0[1]);
+		rpy0[1] =  atan2(fz0a0[0], sqrt(fz0a0[1]*fz0a0[1] + fz0a0[2]*fz0a0[2]));
+		rpy0[2] =  0;
+		// "matrix C" `\_("o)_/`
+		pony->imu->sol.rpy[2] = 0;
+		pony_linal_rpy2mat(pony->imu->sol.L, pony->imu->sol.rpy); // Axz^T(t)
+			// how to produce matrix A_z_x_t0: via angles at either t0, or t `\_("o)_/`
+		pony_linal_rpy2mat(L0, rpy0); // Azx(t0)
+		pony_linal_mmul1T(D, pony->imu->sol.L, Azz0, 3,3,3);
+		pony_linal_mmul  (C, D, L0, 3,3,3);
+		// "matrix D" `\_("o)_/`	 // only the elements being used	
+		D[2] = -sut*clt;
+		D[5] = (1 - cut)*slt*clt;
+		// heading(t) `\_("o)_/`
+		pony->imu->sol.rpy[2] = atan2(-C[2]*D[5] + C[5]*D[2], C[2]*D[2] + C[5]*D[5]);
+		pony->imu->sol.rpy_valid = 1;
+		// attitude matrix
+		pony_linal_rpy2mat(pony->imu->sol.L, pony->imu->sol.rpy);
+		pony->imu->sol.L_valid = 1;
+		// renew quaternion
+		pony_linal_mat2quat(pony->imu->sol.q  , pony->imu->sol.L);
+		pony->imu->sol.q_valid   = 1;		
+		// instrumental frame update: Azz0(t+dt) = (E + [w x]*sin(|w*dt|)/|w| + [w x]^2*(1-cos(|w*dt|)/|?|^2)*Azz0(t) - Rodrigues' rotation formula
+		for (i = 0; i < 3; i++)
+			a[i] = pony->imu->w[i]*dt; // a = w*dt
+		pony_linal_eul2mat(C,a);       // � = E + [a x]*sin(|a|)/|a| + [a x]^2*(1-cos(|a|)/|a|^2
+		for (i = 0; i < 3; i++) {      // matrix multiplication overwriting Azz0
+			for (j = 0; j < 3; j++)
+				a[j] = Azz0[j*3+i];    // i-th column of Azz0 previous value
+			for (j = 0; j < 3; j++)
+				for (k = 0, Azz0[j*3+i] = 0; k < 3; k++)
+					Azz0[j*3+i] += C[j*3+k]*a[k]; // replace column with matrix product: Azz0(t+dt) = C*Azz0(t)
+		}
+
+	}
+
+}

--- a/ins/pony_ins_alignment.h
+++ b/ins/pony_ins_alignment.h
@@ -1,0 +1,9 @@
+// Aug-2020
+//
+/*	pony_ins_alignment 
+	
+	pony plugins for ins initial alignment (initial attitude matrix determination):
+*/
+void pony_ins_alignment_static      (void); // conventional sensor output averaging on a static base
+void pony_ins_alignment_rotating    (void); // gravity vector approximation in inertial reference
+void pony_ins_alignment_rotating_rpy(void); // gravity vector approximation in inertial reference, but matrix is computed via roll, pitch and yaw=true heading, if defined

--- a/ins/pony_ins_attitude.c
+++ b/ins/pony_ins_attitude.c
@@ -1,0 +1,165 @@
+// Aug-2020
+//
+/*	pony_ins_attitude
+	
+	pony plugins for ins angular rate integration:
+	
+	- pony_ins_attitude_rodrigues
+		Combines angular rate components or their integrals into Euler rotation vector 
+		for both instrumental frame and navigation frame. Then applies Rodrigues' rotation formula 
+		to each frame. Then derives the transition matrix between them. Quaternion and angles are also updated.
+		Recommended for navigation/tactical grade systems.
+
+	- (planned) pony_ins_attitude_madgwick
+		Planned for future development
+*/
+
+#include <math.h>
+
+#include "../pony.h"
+
+// pony bus version check
+#define PONY_INS_ATTITUDE_BUS_VERSION_REQUIRED 8
+#if PONY_BUS_VERSION < PONY_INS_ATTITUDE_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+/* pony_ins_attitude_rodrigues - pony plugin
+	
+	Combines angular rate components or their integrals into Euler rotation vector 
+	for both instrumental frame and navigation frame. Then applies Rodrigues' rotation formula 
+	to each frame. Then derives the transition matrix between them. Quaternion and angles are also updated.
+	Recommended for navigation/tactical grade systems.
+
+	description:
+		    
+		L(t+dt) = A L(t) C^T,
+		    
+		where
+		A = E + [a x]*sin(a)/|a| + [a x]^2*(1-cos(a))/|a|^2
+		C = E + [c x]*sin(c)/|c| + [c x]^2*(1-cos(c))/|c|^2,
+		a = w*dt, c = (W + u)*dt
+		        [  0   v3 -v2 ]
+		[v x] = [ -v3  0   v1 ] for v = a, v = c
+	            [  v2 -v1  0  ]
+				
+		pony core function pony_linal_eul2mat safely uses Taylor expansions for |a|,|c| < 2^-8
+		
+	uses:
+		pony->imu->t
+		pony->imu->sol.L
+		pony->imu->sol.L_valid
+		pony->imu->w
+		pony->imu->w_valid
+		pony->imu->W
+		pony->imu->W_valid
+		pony->imu->sol.llh
+		pony->imu->sol.llh_valid
+
+	changes:
+		pony->imu->sol.L
+		pony->imu->sol.L_valid
+		pony->imu->sol.q
+		pony->imu->sol.q_valid
+		pony->imu->sol.rpy
+		pony->imu->sol.rpy_valid
+
+	cfg parameters:
+		none
+*/
+void pony_ins_attitude_rodrigues(void) {
+
+	static double t0 = -1; // previous time
+	static double 		   
+		 C[9],             // intermediate matrix
+		*L;                // pointer to attitude matrix in solution
+
+	double 
+		   dt,	           // time step
+		   a[3];           // Euler rotation vector
+	size_t i;              // common index variable
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// drop validity flags
+		pony->imu->sol.  q_valid = 0;
+		pony->imu->sol.  L_valid = 0;
+		pony->imu->sol.rpy_valid = 0;
+		// set matrix pointer to imu->sol
+		L = pony->imu->sol.L;	
+		// identity quaternion
+		for (i = 1, pony->imu->sol.q[0] = 1; i < 4; i++)
+			pony->imu->sol.q[i] = 0;
+		pony->imu->sol.  q_valid = 1;
+		// identity attitude matrix
+		for (i = 0; i < 9; i++)
+			L[i] = ((i%4) == 0) ? 1 : 0; // for 3x3 matrix, each 4-th element is diagonal
+		pony->imu->sol.  L_valid = 1;
+		// attitude angles for identity matrix
+		pony->imu->sol.rpy[0] = -pony->imu_const.pi/2;	// roll             -90 deg
+		pony->imu->sol.rpy[1] =  0;						// pitch              0 deg
+		pony->imu->sol.rpy[2] = +pony->imu_const.pi/2;	// yaw=true heading +90 deg
+		pony->imu->sol.rpy_valid = 1;
+		// reset previous time
+		t0 = -1;
+
+	}
+
+	else if (pony->mode < 0) {	// termination
+		// do nothing
+	}
+	else						// main cycle
+	{
+		// check for crucial data initialized
+		if (!pony->imu->sol.L_valid || !pony->imu->w_valid)
+			return;
+		// time variables
+		if (t0 < 0) { // first touch
+			t0 = pony->imu->t;
+			return;
+		}
+		dt = pony->imu->t - t0;
+		t0 = pony->imu->t;
+		// a = w*dt
+		for (i = 0; i < 3; i++)
+			a[i] = pony->imu->w[i]*dt;
+		// L = (E + [a x]*sin(a)/|a| + [a x]^2*(1-cos(a))/|a|^2)*L
+		pony_linal_eul2mat(C,a);  // C <- A = E + [a x]*sin(a)/|a| + [a x]^2*(1-cos(a))/|a|^2
+		for (i = 0; i < 3; i++) { // L = A*L
+			a[0] = L[0+i], a[1] = L[3+i], a[2] = L[6+i];
+			L[0+i] = C[0]*a[0] + C[1]*a[1] + C[2]*a[2];
+			L[3+i] = C[3]*a[0] + C[4]*a[1] + C[5]*a[2];
+			L[6+i] = C[6]*a[0] + C[7]*a[1] + C[8]*a[2];
+		}
+		// a <- c = (W + u)*dt
+		for (i = 0; i < 3; i++)
+			a[i] = pony->imu->W_valid ? pony->imu->W[i] : 0;
+		if (pony->imu->sol.llh_valid) {
+			a[1] += pony->imu_const.u*cos(pony->imu->sol.llh[1]);
+			a[2] += pony->imu_const.u*sin(pony->imu->sol.llh[1]);
+		}
+		for (i = 0; i < 3; i++)
+			a[i] *= dt;
+		// L = L*(E + [c x]*sin(c)/|c| + [c x]^2*(1-cos(c))/|c|^2)^T
+		pony_linal_eul2mat(C,a);     // C = E + [c x]*sin(c)/|c| + [c x]^2*(1-cos(c))/|c|^2
+		for (i = 0; i < 9; i += 3) { // L = L*C^T
+			a[0] = L[i+0], a[1] = L[i+1], a[2] = L[i+2];
+			L[i+0] = a[0]*C[0] + a[1]*C[1] + a[2]*C[2];
+			L[i+1] = a[0]*C[3] + a[1]*C[4] + a[2]*C[5];
+			L[i+2] = a[0]*C[6] + a[1]*C[7] + a[2]*C[8];
+		}
+		// renew quaternion
+		pony_linal_mat2quat(pony->imu->sol.q ,L);
+		pony->imu->sol.q_valid   = 1;
+		// renew angles
+		pony_linal_mat2rpy(pony->imu->sol.rpy,L);
+		pony->imu->sol.rpy_valid = 1;
+
+	}
+
+}

--- a/ins/pony_ins_attitude.h
+++ b/ins/pony_ins_attitude.h
@@ -1,0 +1,8 @@
+// Aug-2020
+//
+/*	pony_ins_attitude
+	
+	pony plugins for ins angular rate integration:
+*/
+void pony_ins_attitude_rodrigues(void); // via Euler vector using Rodrigues' rotation formula
+void pony_ins_attitude_madgwick (void); // via Madgwick filter fused with accelerometer data

--- a/ins/pony_ins_gravity.c
+++ b/ins/pony_ins_gravity.c
@@ -1,0 +1,246 @@
+// Aug-2020
+//
+/*	pony_ins_gravity 
+	
+	pony plugins for gravity model calculations:
+
+	- pony_ins_gravity_constant 
+		Takes the magnitude of average accelerometer output vector 
+		and puts it into vertical gravity component, which then remains constant.
+		Recommended for low-grade systems, especially when no reference coordinates available.
+
+	- pony_ins_gravity_normal
+		Computes conventional Earth normal gravity model as in GRS80, etc.,
+		but takes Earth model constants from pony->imu_const variables.
+		Accounts for both latitude and altitude, as well as for plumb line curvature above ellipsoid.
+		Recommended for conventional navigation grade systems.
+
+	- (planned) pony_ins_gravity_egm08
+		Planned for future development.
+	
+*/
+
+#include <math.h>
+#include <stdlib.h>
+
+#include "../pony.h"
+
+// pony bus version check
+#define PONY_INS_GRAVITY_BUS_VERSION_REQUIRED 8
+#if PONY_BUS_VERSION < PONY_INS_GRAVITY_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+/* pony_ins_gravity_constant - pony plugin
+	
+	Takes the magnitude of average accelerometer output vector 
+	and puts it into vertical gravity component, which then remains constant.
+	Recommended for low-grade systems, especially when no reference coordinates available.
+
+	description:
+		    [   0  ]
+		g = [   0  ] = const,
+		    [-|<f>|]
+		where <f> is the specific force vector as measured by accelerometers
+		averaged over an initial alignment period specified in the configuration string
+	
+	uses:
+		pony->imu->t
+		pony->imu->f
+		pony->imu->f_valid
+
+	changes:
+		pony->imu->g
+		pony->imu->g_valid
+
+	cfg parameters:
+		{imu: alignment} - imu initial alignment duration, sec
+			type :   floating point
+			range:   0+ to +inf
+			default: 60
+			example: {imu: alignment = 300}
+*/
+void pony_ins_gravity_constant(void) {
+
+	const char   t0_token[] = "alignment"; // alignment duration parameter name in configuration
+	const double t0_default = 60;          // default alignment duration
+
+	static double
+		f[3] = {0,0,0}, // average specific force vector measured by accelerometers
+		g3   =  0,      // its norm
+		t0   = -1;      // imu initial alignment duration
+	static long n = 0;  // number of measurements used so far
+
+	char   *cfg_ptr;    // pointer to a substring in configuration
+	double  n1_n;       // (n - 1)/n
+	size_t  i;          // index
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// initial values
+		n  =  0;
+		t0 = -1;
+		// zero average specific force
+		for (i = 0; i < 3; i++)
+			f[i] = 0;
+		// parse alignment duration from configuration string
+		cfg_ptr = pony_locate_token(t0_token, pony->imu->cfg, pony->imu->cfglength, '=');
+		if (cfg_ptr != NULL)
+			t0 = atof(cfg_ptr);		
+		// if not found or invalid, set to default
+		if (cfg_ptr == NULL || t0 <= 0)
+			t0 = t0_default;
+
+	}
+	else if (pony->mode < 0) {	// terminate
+		// do nothing
+	}
+
+	else						// main cycle
+	{
+		// validity flag down
+		pony->imu->g_valid = 0;
+
+		if (pony->imu->t <= t0 && pony->imu->f_valid) { // while alignment goes on, and accelerometer measurements are available
+			n++;
+			n1_n = (n - 1.0)/n;
+			for (i = 0; i < 3; i++)
+				f[i] = f[i]*n1_n + pony->imu->f[i]/n; // averaging components
+			g3 = -pony_linal_vnorm(f,3);                   // renew magnitude, negative
+		}
+		// zero Eastern and Northern components
+		pony->imu->g[0] = 0;
+		pony->imu->g[1] = 0;
+		// vertical component, negative magnitude of average measured specific force vector
+		pony->imu->g[2] = g3;
+		// validity flag up
+		pony->imu->g_valid = 1;
+	}
+
+}
+
+/* pony_ins_gravity_normal - pony plugin
+	
+	Computes conventional Earth normal gravity model as in GRS80, etc.,
+	but takes Earth model constants from pony->imu_const variables.
+	Accounts for both latitude and altitude, as well as for plumb line curvature above ellipsoid.
+	Recommended for conventional navigation grade systems.
+
+	description:
+		if pony->imu->sol.llh coordinates are valid, takes them as reference point to calculate gravity at
+		else if pony->sol (hybrid solution) coordinates are valid, uses them
+		otherwise takes latitude of pi/4 and zero altitude as reference point
+
+		g[0] = gE = 0
+		g[1] = gN = -fg*sin(2*lat)*h/a
+		g[2] = gU = -ge*[1 + fg*sin(lat)^2 - f4/4*sin(2*lat)^2]*[1 - 2*(1 + f*cos(2*lat) + m)*h/a]
+
+		where
+
+		- lat   is  geographical latitude
+		- h     is  geographical altitude above Earth ellipsoid
+		- a     is  Earth ellipsoid semimajor axis
+		- fg    is  Earth gravity flattening
+		- ge    is  Earth gravity at equator
+		- f     is  Earth ellipsoid flattening
+		- m, f4 are Earth gravity model auxiliary constants
+	
+	uses:
+		pony->imu->sol.llh
+		pony->imu->sol.llh_valid
+		pony->sol.llh
+		pony->sol.llh_valid
+
+	changes:
+		pony->imu->g
+		pony->imu->g_valid
+
+	cfg parameters:
+		none
+*/
+void pony_ins_gravity_normal(void) {
+
+	static double
+		f    = 0, // Earth ellipsoid flattening f = (a - b)/a
+		m    = 0, // gravitational parameter, m = [u^2 a^2 b]/[GM], ratio between centrifugal and gravitational accelerations on the equator of a shpere having the same mass and volume as the Earth does
+		f4_4 = 0; // coefficient for the second harmonic term, f4/4 = 5/2 f m - 1/2 f^2
+
+	double 
+		lat,	  // geographical latitude		
+		h,		  // geographical altitude from reference ellipsoid
+		sinlat,	  //   sine of latitude
+		sin2lat,  //   sine of twofold latitude
+		cos2lat,  // cosine of twofold latitude
+		h_a,	  // ratio between altitude and ellipsoid semimajor axis
+		b_a;	  // ratio between Earth ellipsoid semiminor and semimajor axes, b/a = sqrt(1 - e^2)
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+		
+		// ratio between Earth ellipsoid semiminor and semimajor axes
+		b_a = sqrt(1 - pony->imu_const.e2); // b/a = sqrt(1 - e^2)
+		// Earth ellipsoid flattening 
+		f = 1 - b_a; // as from definitions: e^2 = (a^2 - b^2)/a^2, f = (a - b)/a
+		// gravitational parameter, as derived from section 3 of Geodetic Reference System 80 by H. Moritz (GRS-80): 
+			// from ge = GM/ab (1 - m - m/6 e'q0'/q0), 
+			// and  gp = GM/a^2 (1 + m/3 e'q0'/q0), 
+			// and  f + fg = u^2 b / ge (1 + e'/2 q0'/q0)
+			// let  k   = 1/2 e'q0'/q0 = (f + fg)/(u^2 b) ge - 1, 
+			// let  eps = 1 / (gp/ge*a/b - 1) = 1/((fg + 1)/sqrt(1 - e^2) - 1), 
+			// then m   = 1/(k*(eps + 1/3) + eps + 1)
+		f4_4 = (f + pony->imu_const.fg)/(pony->imu_const.u*pony->imu_const.u*pony->imu_const.a*b_a)*pony->imu_const.ge - 1; // use f4_4 variable instead of k
+		m    = 1/((pony->imu_const.fg + 1)/b_a - 1);
+		m    = 1/(f4_4*(m+1.0/3) + m + 1);
+		// coefficient for the second harmonic term
+		f4_4 = f/8*(5*m - f); // f4 = -1/2 f^2 + 5/2 f m, as in (2-115), Physical Geodesy, W.Heiskanen H.Moritz, 1993, p. 76, or section 3 of Geodetic Reference System 80 by H. Moritz (GRS-80), corrected for skipped minus sign
+
+	}
+
+	else if (pony->mode < 0) {	// terminate
+		// do nothing
+	}
+
+	else						// main cycle
+	{
+		// validity flag down
+		pony->imu->g_valid = 0;
+		// define latitude and altitude
+		if (pony->imu->sol.llh_valid) { // from imu data, if valid
+			lat = pony->imu->sol.llh[1];
+			h   = pony->imu->sol.llh[2];
+		}
+		else if (pony->sol.llh_valid) { // from hybrid solution, if valid
+			lat = pony->sol.llh[1];
+			h   = pony->sol.llh[2];
+		}
+		else {                          // default values
+			lat = pony->imu_const.pi/4; 
+			h   = 0;
+		}
+		sinlat  = sin(  lat);
+		sin2lat = sin(2*lat);
+		cos2lat = cos(2*lat);
+		h_a = h/pony->imu_const.a;
+		// Eastern component - zero for normal gravity
+		pony->imu->g[0] = 0;
+		// Northern deflection with altitude above ellipsoid from plumb line curvature, as in (5-34), Physical Geodesy, W.Heiskanen H.Moritz, 1993, p. 196
+		pony->imu->g[1] = -pony->imu_const.fg*sin2lat*h_a;
+		// vertical component, as from section 3 of Geodetic Reference System 80 by H. Moritz (GRS-80)
+		pony->imu->g[2] = -pony->imu_const.ge*
+			(1 + pony->imu_const.fg*sinlat*sinlat - f4_4*sin2lat*sin2lat)*
+			(1 - 2*(1 + f*cos2lat + m)*h_a);
+		// validity flag up
+		pony->imu->g_valid = 1;
+
+	}
+
+}

--- a/ins/pony_ins_gravity.h
+++ b/ins/pony_ins_gravity.h
@@ -1,0 +1,9 @@
+// Aug-2020
+//
+/*	pony_ins_gravity 
+	
+	pony plugins for gravity model calculations:
+*/
+void pony_ins_gravity_constant(void); // magnitude of average accelerometer output vector as constant gravity value
+void pony_ins_gravity_normal  (void); // conventional Earth normal gravity model
+void pony_ins_gravity_egm08   (void); // planned for future development

--- a/ins/pony_ins_motion.c
+++ b/ins/pony_ins_motion.c
@@ -1,0 +1,431 @@
+// Aug-2020
+//
+/*	pony_ins_motion
+	
+	pony plugins for ins position and velocity algorithms:
+	
+	- pony_ins_motion_euler
+		Numerically integrates Newton's second Law in local level navigation frame 
+		using first-order Euler's method over the Earth reference ellipsoid. 
+		Updates velocity and geographical coordinates. 
+		Not suitable near the Earth's poles.
+		
+	- (planned) pony_ins_motion_sculling
+		Planned for future development
+		
+	- pony_ins_motion_vertical_damping
+		Restrains vertical error exponential growth by either damping
+		vertical velocity to zero, or to an external reference like
+		altitude/rate derived from air data system and/or gnss, etc.
+		Recommended when using normal gravity model and/or long navigation timeframe.
+*/
+
+#include <math.h>
+
+#include "../pony.h"
+
+// pony bus version check
+#define PONY_INS_MOTION_BUS_VERSION_REQUIRED 8
+#if PONY_BUS_VERSION < PONY_INS_MOTION_BUS_VERSION_REQUIRED
+	#error "pony bus version check failed, consider fetching the latest version"
+#endif
+
+// service functions
+double pony_ins_motion_parse_double(const char *token, char *src, const size_t len, double range[2], const double default_value);
+void   pony_ins_motion_flip_sol_over_pole(pony_sol *sol);
+
+/* pony_ins_motion_euler - pony plugin
+	
+	Numerically integrates Newton's second Law in local level navigation frame 
+	using first-order Euler's method over the Earth reference ellipsoid. 
+	Updates velocity and geographical coordinates. 
+	Not suitable near the Earth's poles.
+
+	description:
+	    
+		V  (t+dt) = V  (t) + dt*([(W + 2u) x]*V (t) +  L^T*f + g)
+		lon(t+dt) = lon(t) + dt*              Ve(t)/((Re + alt(t))*cos(lat(t)))
+		lat(t+dt) = lat(t) + dt*              Vn(t)/( Rn + alt(t))
+		alt(t+dt) = alt(t) + dt*              Vu(t)              
+		    
+		where
+		    [Ve]          [  0   v3 -v2 ]
+		V = [Vn], [v x] = [ -v3  0   v1 ] for v = W + 2u,
+			[Vu]          [  v2 -v1  0  ]
+		Rn, Re are curvature radii
+		L is attitude matrix
+
+		do not use at the Earth's poles
+		
+	uses:
+		pony->imu->t
+		pony->imu->sol.llh
+		pony->imu->sol.llh_valid
+		pony->imu->sol.v
+		pony->imu->sol.v_valid
+		pony->imu->sol.L
+		pony->imu->sol.L_valid
+		pony->imu->f
+		pony->imu->f_valid
+		pony->imu->g
+		pony->imu->g_valid
+		pony->imu->W
+		pony->imu->W_valid
+
+	changes:
+		pony->imu->sol.v
+		pony->imu->sol.v_valid
+		pony->imu->sol.llh
+		pony->imu->sol.llh_valid
+
+	cfg parameters:
+		{imu: lon} - starting longitude, degrees
+			type :   floating point
+			range:   -180..+180
+			default: 0
+			example: {imu: lon = 37.6}
+		{imu: lat} - starting latitude, degrees
+			type :   floating point
+			range:   -90..+90
+			default: 0
+			example: {imu: lat = 55.7}
+		{imu: alt} - starting altitude, meters
+			type :   floating point
+			range:   -20000..+50000
+			default: 0
+			example: {imu: alt = 151.3}
+*/
+void pony_ins_motion_euler(void) {
+
+	const char 
+		lon_token[] = "lon",        // starting longitude parameter name in configuration
+		lat_token[] = "lat",        // starting latitude  parameter name in configuration
+		alt_token[] = "alt";        // starting altitude  parameter name in configuration
+
+	const double 
+		lon_range[] = {-180, +180},	// longitude range, 0 by default
+		lat_range[] = { -90,  +90},	// latitude  range, 0 by default
+		alt_range[] = {-20e3,50e3},	// altitude  range, 0 by default
+		eps = 1.0/0x0100;			// 2^-8, guaranteed non-zero value in IEEE754 half-precision format
+
+	static double t0  = -1;         // previous time
+
+	double dt;                      // time step
+	double
+		sphi, cphi,	                // sine and cosine of latitude
+		Rn_h, Re_h,	                // south-to-north and east-to-west curvature radii, altitude-adjusted
+		e2s2, e4s4,	                // e^2*sin(phi)^2, (e^2*sin(phi)^2)^2
+		dvrel[3],	                // proper acceleration in navigation frame
+		dvcor[3];	                // Coriolis acceleration in navigation frame
+	size_t i;                       // common index variable
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// drop validity flags
+		pony->imu->sol.  v_valid = 0;
+		pony->imu->sol.llh_valid = 0;		
+		// parse parameters from configuration	
+		pony->imu->sol.llh[0] = // starting longitude
+			pony_ins_motion_parse_double(lon_token, pony->imu->cfg,pony->imu->cfglength, (double *)lon_range,0)
+			/pony->imu_const.rad2deg; // degrees to radians
+		pony->imu->sol.llh[1] = // starting latitude
+			pony_ins_motion_parse_double(lat_token, pony->imu->cfg,pony->imu->cfglength, (double *)lat_range,0)
+			/pony->imu_const.rad2deg; // degrees to radians
+		pony->imu->sol.llh[2] = // starting altitude
+			pony_ins_motion_parse_double(alt_token, pony->imu->cfg,pony->imu->cfglength, (double *)alt_range,0);
+		// raise coordinates validity flag
+		pony->imu->sol.llh_valid = 1;
+		// zero velocity at start
+		for (i = 0; i < 3; i++)
+			pony->imu->sol.v[i] = 0;
+		pony->imu->sol.v_valid = 1;
+		// reset previous time
+		t0 = -1;
+
+	}
+
+	else if (pony->mode < 0) {	// termination
+		// do nothing
+	}
+
+	else						// main cycle
+	{
+		// check for crucial data initialized
+		if (   !pony->imu->sol.  v_valid 
+			|| !pony->imu->sol.llh_valid 
+			|| !pony->imu->sol.  L_valid 
+			|| !pony->imu->f_valid 
+			|| !pony->imu->g_valid)
+			return;
+		// time variables
+		if (t0 < 0) { // first touch
+			t0 = pony->imu->t;
+			return;
+		}
+		dt = pony->imu->t - t0;
+		t0 = pony->imu->t;
+		// ellipsoid geometry
+		sphi = sin(pony->imu->sol.llh[1]);
+		cphi = cos(pony->imu->sol.llh[1]);
+		e2s2 = pony->imu_const.e2*sphi*sphi;
+		e4s4 = e2s2*e2s2;					
+		Re_h = pony->imu_const.a*(1 + e2s2/2 + 3*e4s4/8);	                                        // Taylor expansion within 0.5 m, not altitude-adjusted
+		Rn_h = Re_h*(1 - pony->imu_const.e2)*(1 + e2s2 + e4s4 + e2s2*e4s4) + pony->imu->sol.llh[2]; // Taylor expansion within 0.5 m
+		Re_h += pony->imu->sol.llh[2];						                                        // adjust for altitude
+		// drop validity flags
+		pony->imu->W_valid       = 0;
+		pony->imu->sol.llh_valid = 0;
+		pony->imu->sol.  v_valid = 0;
+		// angular rate of navigation frame relative to the Earth
+		pony->imu->W[0] = -pony->imu->sol.v[1]/Rn_h;
+		pony->imu->W[1] =  pony->imu->sol.v[0]/Re_h;	
+		if (cphi < eps) { // check for Earth pole proximity
+			pony->imu->W[2] = 0;    // freeze
+			pony->imu->W_valid = 0; // drop validity
+		}
+		else {
+			pony->imu->W[2] = pony->imu->sol.v[0]/Re_h*sphi/cphi;
+			pony->imu->W_valid = 1;
+		}
+		// velocity
+			// Coriolis acceleration
+		dvrel[0] = pony->imu->W[0];
+		dvrel[1] = pony->imu->W[1] + 2*pony->imu_const.u*cphi;
+		dvrel[2] = pony->imu->W[2] + 2*pony->imu_const.u*sphi;
+		pony_linal_cross3x1(dvcor, pony->imu->sol.v, dvrel);
+			// proper acceleration
+		pony_linal_mmul1T(dvrel, pony->imu->sol.L, pony->imu->f, 3, 3, 1);
+			// velocity update
+		for (i = 0; i < 3; i++)
+			pony->imu->sol.v[i] += (dvcor[i] + dvrel[i] + pony->imu->g[i])*dt;
+		pony->imu->sol.v_valid = 1;
+		// coordinates
+		if (cphi < eps) { // check for Earth pole proximity
+			pony->imu->sol.llh[2] += pony->imu->sol.v[2]				*dt;
+			pony->imu->sol.llh_valid = 0; // drop validity
+		}
+		else {
+			pony->imu->sol.llh[0] += pony->imu->sol.v[0]/(Re_h*cphi)	*dt;
+			pony->imu->sol.llh[1] += pony->imu->sol.v[1]/ Rn_h			*dt;
+			pony->imu->sol.llh[2] += pony->imu->sol.v[2]				*dt;
+			// flip latitude if crossed a pole
+			if (pony->imu->sol.llh[1] < -pony->imu_const.pi/2) { // South pole
+				pony->imu->sol.llh[1] = -pony->imu_const.pi - pony->imu->sol.llh[1];
+				pony_ins_motion_flip_sol_over_pole(&(pony->imu->sol));			
+			}
+			if (pony->imu->sol.llh[1] > +pony->imu_const.pi/2) { // North pole
+				pony->imu->sol.llh[1] = +pony->imu_const.pi - pony->imu->sol.llh[1];
+				pony_ins_motion_flip_sol_over_pole(&(pony->imu->sol));			
+			}
+			// adjust longitude into range
+			while (pony->imu->sol.llh[0] < -pony->imu_const.pi)
+				pony->imu->sol.llh[0] += 2*pony->imu_const.pi;
+			while (pony->imu->sol.llh[0] > +pony->imu_const.pi)
+				pony->imu->sol.llh[0] -= 2*pony->imu_const.pi;
+			pony->imu->sol.llh_valid = 1;
+		}
+	}
+
+}
+
+/* pony_ins_motion_vertical_damping - pony plugin
+	
+	Restrains vertical error exponential growth by either damping
+	vertical velocity to zero, or to an external reference like
+	altitude/rate derived from air data system and/or gnss, etc.
+	Recommended when using normal gravity model and/or long navigation timeframe.
+
+	description:
+		performs vertical channel correction using
+		- zero vertical velocity model
+		- air data altitude and altitude rate of change
+		- (planned) gnss-derived altitude and vertical velocity
+		- etc.
+								      [x]          [v]
+		algorithm state vector is y = [v], dy/dt = [q], M[q^2] = vvs^2
+
+	uses:
+		pony->imu->t
+		pony->air->alt
+		pony->air->alt_valid
+		pony->air->alt_std
+		pony->air->vv
+		pony->air->vv_valid
+		pony->air->vv_std
+		pony->imu->sol.llh[2]
+		pony->imu->sol.llh_valid
+		pony->imu->sol.  v[2]
+		pony->imu->sol.  v_valid
+
+	changes:
+		pony->imu->sol.llh[2]
+		pony->imu->sol.  v[2]
+
+	cfg parameters:
+		{imu: vertical_damping_stdev} - vertical velocity stdev (vvs), m/s
+			type :   floating point
+			range:   >0
+			default: 2^20 (no damping)
+			example: {imu: vertical_damping_stdev = 9e9}
+			set vvs = 0 to force zero vertical velocity
+			negative values result in default
+*/
+void pony_ins_motion_vertical_damping(void) {
+
+	const char vvs_token[] = "vertical_damping_stdev"; // vertical velocity stdev parameter name in configuration
+
+	const double 
+		vvs_def = (double)(0x100000),                  // 2^20, vertical velocity stdev default value
+		sqrt2   = 1.4142135623730951;                  // sqrt(2)
+
+	static double 
+		t0           = -1, // previous time
+		vvs          =  0, // vertical velocity stdev
+		air_alt_last =  0; // previous value of air altitude
+
+	double 
+		dt,	  // time step
+		x,    // inertial altitude
+		v,    // inertial vertical velocity
+		z,    // reference information
+		s,    // reference information a priori stdev
+		h[2], // model coefficients
+		y[2], // algorithm state vector
+		S[3], // upper-triangular part of cobariance Cholesky factorization
+		K[2], // Kalman gain
+		w;    // weight
+
+
+	// check if imu data has been initialized
+	if (pony->imu == NULL)
+		return;
+
+	if (pony->mode == 0) {		// init
+
+		// reset time
+		t0 = -1;
+		// parse vertical velocity stdev from configuration string
+		vvs = pony_ins_motion_parse_double(vvs_token, pony->imu->cfg, pony->imu->cfglength, NULL, vvs_def);
+		if (vvs < 0)
+			vvs = vvs_def;
+
+	}
+
+	else if (pony->mode < 0) {	// termination
+		// do nothing
+	}
+	else						// main cycle
+	{
+		// time variables
+		if (t0 < 0) {
+			t0 = pony->imu->t;
+			if (pony->air != NULL && pony->air->alt_valid)
+				air_alt_last = pony->air->alt;
+			return;
+		}
+		dt = pony->imu->t - t0;
+		t0 = pony->imu->t;
+		if (dt <= 0)
+			return;
+		// estimation init 
+		if (pony->imu->sol.llh_valid) x = pony->imu->sol.llh[2]; else x = 0;
+		if (pony->imu->sol.  v_valid) v = pony->imu->sol.  v[2]; else v = 0;
+		y[0] = x, y[1] = v;
+		S[0] = vvs_def*dt, S[1] = 0, S[2] = 1;
+		// zero vertical velocity
+		if (pony->imu->sol.v_valid) {
+			s = vvs;
+			z = 0.0;
+			h[0] = 0, h[1] = 1;
+			pony_linal_kalman_update(y,S,K, z,h,s, 2);
+		}
+		// check for air data
+		if (pony->air != NULL) {
+			if (pony->air->alt_valid && pony->imu->sol.llh_valid) { // altitude data present
+				// altitude
+				s = sqrt2*( (pony->air->alt_std > 0) ? (pony->air->alt_std) : vvs );
+				z = pony->air->alt + air_alt_last; // decorrelated with velocity information
+				h[0] = 2, h[1] = -dt;
+				pony_linal_kalman_update(y,S,K, z,h,s, 2);
+				// altitude rate of change
+				z = pony->air->alt - air_alt_last; // decorrelated with altitude information
+				h[0] = 0, h[1] = dt;
+				pony_linal_kalman_update(y,S,K, z,h,s, 2);
+				air_alt_last = pony->air->alt;
+			}
+			if (pony->air->vv_valid && pony->imu->sol.v_valid) { // vertical velocity data present
+				z = pony->air->vv - pony->imu->sol.v[2];
+				s = (pony->air-> vv_std > 0) ? (pony->air-> vv_std) : vvs;
+				pony_linal_kalman_update(y,S,K, z,h,s, 2);
+			}
+		}
+
+		// check for gnss data
+		//
+		// TBD
+		//
+
+		// vertical channel correction
+		s = sqrt(S[0]*S[0] + S[1]*S[1]);  // altitude stdev estimate
+		w = s + S[2]*dt;                  // sum of altitude stdev and velocity contribution into stdev
+		if (pony->imu->sol.llh_valid) 
+			pony->imu->sol.llh[2] = y[0]; // replace altitude by its estimated value
+		if (pony->imu->sol.  v_valid) {
+			pony->imu->sol.llh[2] += 2*s      /w*(y[1]-v)*dt; // weighted correction to hold dx/dt = v
+			pony->imu->sol.  v[2] = y[1]; // replace vertical velocity by its estimated value
+		}
+		if (pony->imu->sol.llh_valid) 
+			pony->imu->sol.  v[2] += 2*S[2]*dt/w*(y[0]-x)/dt; // weighted correction to hold dx/dt = v
+
+	}
+
+}
+
+
+
+
+
+// service functions
+double pony_ins_motion_parse_double(const char *token, char *src, const size_t len, double *range, const double default_value) {
+
+	char   *cfg_ptr; // pointer to a substring
+	double  val;     // value
+
+	// ensure variable to be initialized
+	val = default_value;
+	// parse token from src
+	cfg_ptr = pony_locate_token(token, src, len, '=');
+	if (cfg_ptr != NULL)
+		val = atof(cfg_ptr);
+	// if not found or out of range, set to default
+	if ( cfg_ptr == NULL || (range != NULL && (range[0] > range[1] || val < range[0] || range[1] < val)) )
+		val = default_value;
+	return val;
+
+}
+
+void pony_ins_motion_flip_sol_over_pole(pony_sol *sol) {
+
+	size_t i;
+
+	// longitude
+	sol->llh[0] +=  pony->imu_const.pi;
+	// velocity
+	sol->v  [0]  = -sol->v[0];
+	sol->v  [1]  = -sol->v[1];
+	// attitude matrix
+	for (i = 0; i < 3; i++) {
+		sol->L[i*3+0] = -sol->L[i*3+0];
+		sol->L[i*3+1] = -sol->L[i*3+1];
+	}
+	// update quaternion
+	pony_linal_mat2quat(sol->q  ,sol->L);
+	// update angles
+	pony_linal_mat2rpy (sol->rpy,sol->L);
+
+}

--- a/ins/pony_ins_motion.h
+++ b/ins/pony_ins_motion.h
@@ -1,0 +1,9 @@
+// Aug-2020
+//
+/*	pony_ins_motion
+	
+	pony plugins for ins position and velocity algorithms
+*/
+void pony_ins_motion_euler           (void); // velocity and position using first-order Euler integration
+void pony_ins_motion_sculling        (void); // planned for future development
+void pony_ins_motion_vertical_damping(void); // vertical error buildup damping

--- a/pony.h
+++ b/pony.h
@@ -1,9 +1,12 @@
-// Jun-2020
+// Aug-2020
 //
+#ifndef PONY_H_
+#define PONY_H_
+
 #include <stddef.h>
 
 // PONY core declarations
-#define pony_bus_version 8		// current bus version
+#define PONY_BUS_VERSION 9		// current bus version
 
 // TIME EPOCH
 typedef struct 		// Julian-type time epoch
@@ -26,17 +29,17 @@ typedef struct			// navigation solution structure
 	double llh[3];			// geodetic coordinates: longitude (rad), latitude (rad), height (meters)
 	char llh_valid;			// validity flag (0/1), or a number of valid measurements used
 
-	double v[3];			// relative-to-Earth velocity vector coordinates in local-level geodetic or cartesian frame, meters per second
+	double v[3];			// relative-to-Earth velocity vector coordinates in local-level geodetic cartesian frame, meters per second
 	char v_valid;			// validity flag (0/1), or a number of valid measurements used
 	double v_std;			// velocity RMS ("standard") deviation estimate, meters per second
 
-	double q[4];			// attitude quaternion, relative to local-level or cartesian frame
+	double q[4];			// attitude quaternion, relative to local-level geodetic cartesian frame
 	char q_valid;			// validity flag (0/1), or a number of valid measurements used
 
-	double L[9];			// attitude matrix for the transition from local-level or cartesian frame, row-wise: L[0] = L_11, L[1] = L_12, ..., L[8] = L[33]
+	double L[9];			// attitude matrix for the transition from local-level geodetic cartesian frame, row-wise: L[0] = L_11, L[1] = L_12, ..., L[8] = L[33]
 	char L_valid;			// validity flag (0/1), or a number of valid measurements used
 
-	double rpy[3];			// attitude angles relative to local-level frame: roll (rad), pitch (rad), yaw = true heading (rad)
+	double rpy[3];			// attitude angles relative to local-level geodetic cartesian frame: roll (rad), pitch (rad), yaw (rad)
 	char rpy_valid;			// validity flag (0/1), or a number of valid measurements used
 
 	double dt;				// clock bias
@@ -56,7 +59,7 @@ typedef struct		// inertial navigation constants
 	double 
 		pi,			// pi
 		rad2deg,	// 180/pi
-		// Earth parameters as in GRS-80 by H. Moritz // Journal of Geodesy (2000) 74 (1): pp. 128–162
+		// Earth parameters as in GRS-80 by H. Moritz // Journal of Geodesy (2000) 74 (1): pp. 128-162
 		u,			// Earth rotation rate, rad/s
 		a,			// Earth ellipsoid semi-major axis, m
 		e2,			// Earth ellipsoid first eccentricity squared
@@ -67,8 +70,8 @@ typedef struct		// inertial navigation constants
 	// IMU
 typedef struct		// inertial measurement unit
 {
-	char* cfg;			// pointer to IMU configuration string
-	size_t cfglength;	// IMU configuration string length
+	char* cfg;			// pointer to IMU configuration substring
+	size_t cfglength;	// IMU configuration substring length
 
 	double t;			// measurement update time
 
@@ -188,8 +191,8 @@ typedef struct		// GNSS constants
 	// GPS
 typedef struct				// GPS constellation data
 {
-	char* cfg;				// GPS configuration string
-	size_t cfglength;		// configuration string length
+	char* cfg;				// GPS configuration substring
+	size_t cfglength;		// GPS configuration substring length
 
 	size_t max_sat_count;	// maximum supported number of satellites
 	size_t max_eph_count;	// maximum supported number of ephemeris
@@ -210,8 +213,8 @@ typedef struct				// GPS constellation data
 	// GLONASS
 typedef struct				// GLONASS constellation data
 {
-	char* cfg;				// GLONASS configuration string
-	size_t cfglength;		// configuration string length
+	char* cfg;				// GLONASS configuration substring
+	size_t cfglength;		// GLONASS configuration substring length
 
 	size_t max_sat_count;	// maximum supported number of satellites
 	size_t max_eph_count;	// maximum supported number of ephemeris
@@ -229,8 +232,8 @@ typedef struct				// GLONASS constellation data
 	// GALILEO
 typedef struct				// Galileo constellation data
 {
-	char* cfg;				// Galileo configuration string
-	size_t cfglength;		// configuration string length
+	char* cfg;				// Galileo configuration substring
+	size_t cfglength;		// Galileo configuration substring length
 
 	size_t max_sat_count;	// maximum supported number of satellites
 	size_t max_eph_count;	// maximum supported number of ephemeris
@@ -250,8 +253,8 @@ typedef struct				// Galileo constellation data
 		// BEIDOU
 typedef struct				// BeiDou constellation data
 {
-	char* cfg;				// BeiDou configuration string
-	size_t cfglength;		// configuration string length
+	char* cfg;				// BeiDou configuration substring
+	size_t cfglength;		// BeiDouconfiguration substring length
 
 	size_t max_sat_count;	// maximum supported number of satellites
 	size_t max_eph_count;	// maximum supported number of ephemeris
@@ -287,11 +290,11 @@ typedef struct // GNSS operation settings
 	// GNSS
 typedef struct						// global navigation satellite systems data
 {
-	char* cfg;						// full GNSS configuration string pointer, NULL if gnss is not used
-	size_t cfglength;				// full GNSS configuration string length
+	char* cfg;						// full GNSS configuration substring pointer, NULL if gnss is not used
+	size_t cfglength;				// full GNSS configuration substring length
 
-	char* cfg_settings;				// pointer to a part of GNSS configuration string common to all systems
-	size_t settings_length;			// length of the part of GNSS configuration string common to all systems
+	char* cfg_settings;				// pointer to a part of GNSS configuration substring common to all systems
+	size_t settings_length;			// length of the part of GNSS configuration substring common to all systems
 
 	pony_gnss_settings settings;	// GNSS operation settings
 
@@ -313,19 +316,22 @@ typedef struct						// global navigation satellite systems data
 // AIR DATA
 typedef struct
 {
-	char* cfg;				// pointer to air data configuration string
-	size_t cfglength;		// air data configuration string length
+	char* cfg;			// pointer to air data configuration substring
+	size_t cfglength;	// air data configuration substring length
 
-	double t;				// measurement update time
+	double t;			// measurement update time
 
-	double alt;				// barometric altitude
-	char alt_valid;			// validity flag (0/1)
+	double alt;			// barometric altitude
+	double alt_std;		// estimated standard deviation, <0 if undefined
+	char   alt_valid;	// validity flag (0/1)
 
-	double vv;				// vertical velocity (vertical speed/rate of climb and descent)
-	char vv_valid;			// validity flag (0/1)
+	double vv;			// vertical velocity (vertical speed/rate of climb and descent)
+	double vv_std;		// estimated standard deviation, <0 if undefined
+	char   vv_valid;	// validity flag (0/1)
 
-	double airspeed;		// airspeed
-	char airspeed_valid;	// validity flag (0/1)
+	double speed;		// airspeed
+	double speed_std;	// estimated standard deviation, <0 if undefined
+	char   speed_valid;	// validity flag (0/1)
 } pony_air;
 
 
@@ -383,7 +389,7 @@ typedef struct					// bus data to be used in host application
 	pony_gnss* gnss;							// global navigation satellite system data pointer
 	size_t gnss_count;							// number of gnss instances
 
-	pony_air* air;								// air data subsystem
+	pony_air* air;								// air data subsystem pointer
 
 	double t;									// system time
 	int mode;									// operation mode: 0 - init, <0 termination, >0 normal operation
@@ -434,6 +440,7 @@ void pony_linal_mat2quat(double *q, double *R);  // 3x3 attitude matrix R to qua
 void pony_linal_quat2mat(double *R, double *q);  // attitude quaternion q (with q0 being scalar part) to a 3x3 matrix R
 void pony_linal_rpy2mat(double *R, double *rpy); // roll, pitch and yaw (radians, airborne frame: X longitudinal, Z right-wing) to a 3x3 transition matrix R from E-N-U
 void pony_linal_mat2rpy(double *rpy, double *R); // 3x3 transition matrix R from E-N-U to roll, pitch and yaw (radians, airborne frame: X longitudinal, Z right-wing)
+void pony_linal_eul2mat(double *R, double *e);   // rotate 3x3 matrix R by 3x1 Euler vector e via Rodrigues' formula: R = (E + sin|e|/|e|*[e,] + (1-cos|e|)/|e|^2*[e,]^2)*R
 
 	// routines for m x m upper-triangular matrices U lined up in a single-dimension array u
 		// index conversion
@@ -449,5 +456,13 @@ void pony_linal_uuT(double *res,  double *u, const size_t m); // square (with tr
 void pony_linal_chol(double *S,  double *P, const size_t m); // Cholesky upper-triangular factorization P = S*S^T, where P is symmetric positive-definite matrix
 
 	// square root Kalman filtering
-double pony_linal_kalman_update(double *x, double *S, double *K,  double z, double *h, double sigma, const size_t m);
+char   pony_linal_check_measurement_residual(double *x, double *S, double z, double *h, double sigma, double k_sigma, const size_t n); // check measurement residual magnitude against predicted covariance level
+double pony_linal_kalman_update(double *x, double *S, double *K,  double z, double *h, double sigma, const size_t n); // kalman filtering - update phase
+void   pony_linal_kalman_predict_I_qI  (           double *S,            double  q2, const size_t n                ); // kalman filtering - prediction phase - identity         state transition -         scalar process noise covariance
+void   pony_linal_kalman_predict_I_qIr (           double *S,            double  q2, const size_t n, const size_t m); // kalman filtering - prediction phase - identity         state transition - reduced scalar process noise covariance
+void   pony_linal_kalman_predict_I_diag(           double *S,            double *q2, const size_t n, const size_t m); // kalman filtering - prediction phase - identity         state transition -       diagonal process noise covariance
+void   pony_linal_kalman_predict_I     (           double *S,            double *Q , const size_t n, const size_t m); // kalman filtering - prediction phase - identity         state transition         
+void   pony_linal_kalman_predict_U_diag(double *x, double *S, double *U, double *q2, const size_t n, const size_t m); // kalman filtering - prediction phase - upper triangular state transition -       diagonal process noise covariance
+void   pony_linal_kalman_predict_U     (double *x, double *S, double *U, double *Q , const size_t n, const size_t m); // kalman filtering - prediction phase - upper triangular state transition 
 
+#endif // PONY_H_


### PR DESCRIPTION
- Capitalize pony_bus_version macro
- Fix pony_linal_mat2rpy function for numerical ambiguity
- Rename `airspeed` to `speed` in air data subsystem (pony->air)
- Add pony_linal_eul2mat function tramsforming Euler rotation vector to transition matrix
- Add Kalman filter prediction phase, a number of functions
- Add pony_linal_check_measurement_residual comparing the magnitude of residual against predicted level
- Add GNSS plugin set
- Add INS plugin set
- Add ifdef _PONY_H guarding macro
- Resolve #19
- Improve comments and descriptions